### PR TITLE
Copy and time formatting edits

### DIFF
--- a/assets/javascripts/discourse/widgets/post-activity-pub-indicator.js
+++ b/assets/javascripts/discourse/widgets/post-activity-pub-indicator.js
@@ -8,7 +8,7 @@ createWidget("post-activity-pub-indicator", {
 
   title(attrs) {
     return I18n.t(`post.discourse_activity_pub.title.${attrs.status}`, {
-      time: attrs.time.format(I18n.t("dates.long_no_year")),
+      time: attrs.time.format("h:mm a, MMM D"),
     });
   },
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -25,7 +25,7 @@ en:
           model_not_ready: ActivityPub is not ready for this %{model_type}
           model_not_active: ActivityPub is not active for this %{model_type}
           model_active:
-            first_post: The first post of a new topic in %{model_name} will be federated %{delay_minutes} minutes after being posted
+            first_post: The first post of a new topic in %{model_name} will be published %{delay_minutes} minutes after being posted
         label:
           active: Active
           not_active: Not Active

--- a/test/javascripts/acceptance/activity-pub-topic-test.js
+++ b/test/javascripts/acceptance/activity-pub-topic-test.js
@@ -93,7 +93,7 @@ acceptance(
       assert.ok(
         exists(
           `.topic-post:nth-of-type(1) .post-info.activity-pub[title='Post was scheduled to be published via ActivityPub at ${scheduledAt.format(
-            I18n.t("dates.long_no_year")
+            "h:mm a, MMM D"
           )}']`
         ),
         "shows the right title"
@@ -127,7 +127,7 @@ acceptance(
       assert.ok(
         exists(
           `.topic-post:nth-of-type(1) .post-info.activity-pub[title='Post was published via ActivityPub at ${publishedAt.format(
-            I18n.t("dates.long_no_year")
+            "h:mm a, MMM D"
           )}']`
         ),
         "shows the right title"
@@ -152,7 +152,7 @@ acceptance(
       assert.ok(
         exists(
           `.topic-post:nth-of-type(1) .post-info.activity-pub[title='ActivityPub note was deleted at ${deletedAt.format(
-            I18n.t("dates.long_no_year")
+            "h:mm a, MMM D"
           )}']`
         ),
         "shows the right title"

--- a/test/javascripts/acceptance/activity-pub-topic-test.js
+++ b/test/javascripts/acceptance/activity-pub-topic-test.js
@@ -8,7 +8,6 @@ import { visit } from "@ember/test-helpers";
 import Site from "discourse/models/site";
 import { cloneJSON } from "discourse-common/lib/object";
 import topicFixtures from "discourse/tests/fixtures/topic";
-import I18n from "I18n";
 
 const createdAt = moment().subtract(2, "days");
 const scheduledAt = moment().subtract(2, "days");


### PR DESCRIPTION
### Time format edit
Time formatting in published_at etc tooltips changed from

```
Post was published via ActivityPub at Jun 1, 9:29 am
```
to

```
Post was published via ActivityPub at 9:29 am, Jun 1
```
There isn't an existing I18n string in the discourse/discourse client locale for this scenario, however I think having the time followed by a short date makes more sense here.

### Copy edit

We've used the term "published" elsewhere (it's the term used in the specification) so we should use it consistently here too (instead of "federated")

```
The first post of a new topic in %{model_name} will be *published* %{delay_minutes} minutes after being posted
```
