### PR TITLE
Add Update activity support to first post only

### DIFF
--- a/app/models/discourse_activity_pub_object.rb
+++ b/app/models/discourse_activity_pub_object.rb
@@ -14,7 +14,7 @@ class DiscourseActivityPubObject < ActiveRecord::Base
     return true unless local?
 
     case ap_type
-    when DiscourseActivityPub::AP::Activity::Create.type
+    when DiscourseActivityPub::AP::Activity::Create.type, DiscourseActivityPub::AP::Activity::Update.type
       !!model && !model.trashed?
     when DiscourseActivityPub::AP::Activity::Delete.type
       !model || model.trashed?
@@ -33,12 +33,8 @@ class DiscourseActivityPubObject < ActiveRecord::Base
     ap = DiscourseActivityPub::AP::Object.from_type(ap_type_sym)
     return unless model.activity_pub_enabled && ap&.composition?
 
-    if ap_type_sym == :update
-      # We don't currently permit updates after publication
-      return if model.activity_pub_published?
-      # We don't permit updates if object has been deleted
-      return if model.activity_pub_deleted?
-    end
+    # We don't permit updates if object has been deleted
+    return if model.activity_pub_deleted? && ap_type_sym == :update
 
     # If we're pre-publication clear all objects and data.
     if !model.activity_pub_published? && ap_type_sym == :delete
@@ -61,14 +57,19 @@ class DiscourseActivityPubObject < ActiveRecord::Base
 
       object.save!
 
-      if ap_type_sym != :update
-        DiscourseActivityPubActivity.create!(
+      unless ap_type_sym == :update && !model.activity_pub_published?
+        activity_attrs = {
           local: true,
           actor_id: model.activity_pub_actor.id,
           object_id: object.id,
           object_type: 'DiscourseActivityPubObject',
           ap_type: ap.type
+        }
+        unless DiscourseActivityPubActivity.exists?(
+          activity_attrs.merge(published_at: nil)
         )
+          DiscourseActivityPubActivity.create!(activity_attrs)
+        end
       end
     end
   end

--- a/app/models/discourse_activity_pub_object.rb
+++ b/app/models/discourse_activity_pub_object.rb
@@ -57,7 +57,7 @@ class DiscourseActivityPubObject < ActiveRecord::Base
 
       object.save!
 
-      unless ap_type_sym == :update && !model.activity_pub_published?
+      unless !model.activity_pub_published? && ap_type_sym == :update
         activity_attrs = {
           local: true,
           actor_id: model.activity_pub_actor.id,

--- a/app/serializers/discourse_activity_pub/ap/object/note_serializer.rb
+++ b/app/serializers/discourse_activity_pub/ap/object/note_serializer.rb
@@ -2,7 +2,8 @@
 
 class DiscourseActivityPub::AP::Object::NoteSerializer < DiscourseActivityPub::AP::ObjectSerializer
   attributes :content,
-             :url
+             :url,
+             :updated
 
   def content
     content = object.content
@@ -22,6 +23,10 @@ class DiscourseActivityPub::AP::Object::NoteSerializer < DiscourseActivityPub::A
 
   def include_url?
     object.stored.local? && !deleted?
+  end
+
+  def include_updated?
+    object.updated.present?
   end
 
   def deleted?

--- a/assets/javascripts/discourse/initializers/activity-pub-initializer.js
+++ b/assets/javascripts/discourse/initializers/activity-pub-initializer.js
@@ -23,6 +23,10 @@ export default {
         "activity_pub_deleted_at",
         "activity_pub_deleted_at"
       );
+      api.includePostAttributes(
+        "activity_pub_updated_at",
+        "activity_pub_updated_at"
+      );
 
       // TODO (future): PR discourse/discourse to add post infos via api
       api.reopenWidget("post-meta-data", {
@@ -43,6 +47,9 @@ export default {
             if (attrs.activity_pub_deleted_at) {
               time = moment(attrs.activity_pub_deleted_at);
               status = "deleted";
+            } else if (attrs.activity_pub_updated_at) {
+              time = moment(attrs.activity_pub_updated_at);
+              status = "updated";
             } else if (attrs.activity_pub_published_at) {
               time = moment(attrs.activity_pub_published_at);
               status = "published";
@@ -94,6 +101,7 @@ export default {
               activity_pub_scheduled_at: data.model.scheduled_at,
               activity_pub_published_at: data.model.published_at,
               activity_pub_deleted_at: data.model.deleted_at,
+              activity_pub_updated_at: data.model.updated_at,
             };
             this.get("model.postStream")
               .triggerActivityPubStateChange(data.model.id, stateProps)

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -107,7 +107,8 @@
 }
 
 .post-info.activity-pub {
-  &.published .d-icon {
+  &.published .d-icon,
+  &.updated .d-icon {
     color: var(--success);
   }
   &.scheduled .d-icon,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -38,3 +38,4 @@ en:
           scheduled: "Post is scheduled to be published via ActivityPub at %{time}"
           scheduled_past: "Post was scheduled to be published via ActivityPub at %{time}"
           deleted: "ActivityPub note was deleted at %{time}"
+          updated: "Post was updated via ActivityPub at %{time}"

--- a/lib/discourse_activity_pub/ap/actor/group.rb
+++ b/lib/discourse_activity_pub/ap/actor/group.rb
@@ -17,7 +17,8 @@ module DiscourseActivityPub
             accept: [:follow],
             reject: [:follow],
             create: [:note],
-            delete: [:note]
+            delete: [:note],
+            update: [:note]
           }
         end
       end

--- a/lib/discourse_activity_pub/ap/object/note.rb
+++ b/lib/discourse_activity_pub/ap/object/note.rb
@@ -12,6 +12,10 @@ module DiscourseActivityPub
           stored&.content
         end
 
+        def updated
+          stored&.updated_at.iso8601
+        end
+
         def can_belong_to
           %i(post)
         end

--- a/spec/fabricators/discourse_activity_pub_activity_fabricator.rb
+++ b/spec/fabricators/discourse_activity_pub_activity_fabricator.rb
@@ -51,6 +51,18 @@ Fabricator(:discourse_activity_pub_activity_create, from: :discourse_activity_pu
   end
 end
 
+Fabricator(:discourse_activity_pub_activity_update, from: :discourse_activity_pub_activity) do
+  ap_type { DiscourseActivityPub::AP::Activity::Update.type }
+  actor { Fabricate(:discourse_activity_pub_actor_group) }
+  object { Fabricate(:discourse_activity_pub_object_note) }
+  local { true }
+
+  after_create do |activity|
+    object.model.custom_fields['activity_pub_published_at'] = Time.now
+    object.model.save_custom_fields(true)
+  end
+end
+
 Fabricator(:discourse_activity_pub_activity_delete, from: :discourse_activity_pub_activity) do
   ap_type { DiscourseActivityPub::AP::Activity::Delete.type }
   actor { Fabricate(:discourse_activity_pub_actor_group) }

--- a/spec/jobs/discourse_activity_pub_deliver_spec.rb
+++ b/spec/jobs/discourse_activity_pub_deliver_spec.rb
@@ -238,5 +238,26 @@ RSpec.describe Jobs::DiscourseActivityPubDeliver do
         end
       end
     end
+
+    context "when delivering an Update" do
+      let(:activity) { Fabricate(:discourse_activity_pub_activity_update) }
+      let(:person) { Fabricate(:discourse_activity_pub_actor_person) }
+
+      it "performs the right request" do
+        body = activity.ap.json
+        body[:to] = person.ap.id
+
+        expect_request(
+          actor_id: activity.actor.id,
+          uri: person.inbox,
+          body: body
+        )
+        execute_job(
+          activity_id: activity.id,
+          from_actor_id: activity.actor.id,
+          to_actor_id: person.id
+        )
+      end
+    end
   end
 end

--- a/spec/lib/discourse_activity_pub/delivery_failure_tracker_spec.rb
+++ b/spec/lib/discourse_activity_pub/delivery_failure_tracker_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 describe DiscourseActivityPub::DeliveryFailureTracker do
-  let!(:actor) { Fabricate(:discourse_activity_pub_actor_person) }
   subject { described_class.new(actor.inbox) }
+
+  let!(:actor) { Fabricate(:discourse_activity_pub_actor_person) }
 
   after do
     Discourse.redis.flushdb

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -28,18 +28,16 @@ RSpec.describe PostRevisor do
       end
 
       describe "with different note content" do
-        it "adds the right error" do
+        it "does not add an error" do
           subject.revise!(user, raw: "#{post.raw} revision inside note")
-          expect(post.errors.present?).to eq(true)
-          expect(post.errors.messages[:base].first).to eq(
-            I18n.t("post.discourse_activity_pub.error.edit_after_publication")
-          )
+          expect(post.errors.present?).to eq(false)
         end
 
-        it "does not perform the edit" do
-          original_raw = post.raw
-          subject.revise!(user, raw: "#{post.raw} revision inside note")
-          expect(post.reload.raw).to eq(original_raw)
+        it "performs the edit" do
+          updated_raw = "#{post.raw} revision inside note"
+          subject.revise!(user, raw: updated_raw)
+          expect(post.reload.raw).to eq(updated_raw)
+          expect(post.activity_pub_content).to eq(updated_raw)
         end
       end
 


### PR DESCRIPTION
Adds update activity support to first post only.
- Publishes an Update activity activity_pub_delivery_delay_minutes after an edit.
- Edits performed while an Update delivery is scheduled (i.e. within the delay period) are added to the schedule Update.
- Tested with revisions (same process as edits).
- Tested with Mastodon.