### PR TITLE
Fix likes error

### DIFF
--- a/app/models/discourse_activity_pub_activity.rb
+++ b/app/models/discourse_activity_pub_activity.rb
@@ -19,12 +19,12 @@ class DiscourseActivityPubActivity < ActiveRecord::Base
     where(ap_type: DiscourseActivityPub::AP::Activity::Like.type)
   }
 
-  def ready?
+  def ready?(parent_ap_type = nil)
     case object_type
     when "DiscourseActivityPubActivity"
       object&.ready?
     when "DiscourseActivityPubObject"
-      object&.ready?(ap_type)
+      object&.ready?(parent_ap_type || ap_type)
     when "DiscourseActivityPubActor"
       object&.ready?
     end

--- a/app/models/discourse_activity_pub_actor.rb
+++ b/app/models/discourse_activity_pub_actor.rb
@@ -22,7 +22,7 @@ class DiscourseActivityPubActor < ActiveRecord::Base
     local? ? true : self.available
   end
 
-  def ready?
+  def ready?(parent_ap_type = nil)
     local? ? model.activity_pub_ready? : available?
   end
 

--- a/app/models/discourse_activity_pub_object.rb
+++ b/app/models/discourse_activity_pub_object.rb
@@ -21,13 +21,14 @@ class DiscourseActivityPubObject < ActiveRecord::Base
     end
   end
 
-  def ready?(ap_type = nil)
+  def ready?(parent_ap_type = nil)
     return true unless local?
 
-    case ap_type
+    case parent_ap_type
     when DiscourseActivityPub::AP::Activity::Create.type,
          DiscourseActivityPub::AP::Activity::Update.type,
-         DiscourseActivityPub::AP::Activity::Like.type
+         DiscourseActivityPub::AP::Activity::Like.type,
+         DiscourseActivityPub::AP::Activity::Undo.type
       !!model && !model.trashed?
     when DiscourseActivityPub::AP::Activity::Delete.type
       !model || model.trashed?

--- a/lib/discourse_activity_pub/ap/activity.rb
+++ b/lib/discourse_activity_pub/ap/activity.rb
@@ -144,7 +144,7 @@ module DiscourseActivityPub
 
         @object = AP::Object.resolve_and_store(json[:object], self)
         return process_failed("cant_find_object") unless object.present?
-        return process_failed("object_not_ready") unless object.stored.ready?
+        return process_failed("object_not_ready") unless object.stored.ready?(type)
         return process_failed("activity_not_supported") unless actor.stored.can_perform_activity?(type, object.type)
 
         true

--- a/lib/discourse_activity_pub/ap/object.rb
+++ b/lib/discourse_activity_pub/ap/object.rb
@@ -169,7 +169,7 @@ module DiscourseActivityPub
         object_id = DiscourseActivityPub::JsonLd.resolve_id(raw_object)
         return process_failed(object_id, "cant_resolve_object") unless object_id.present?
 
-        if activity.composition? || activity.like?
+        if activity.composition?
           object = factory(raw_object)
           return process_failed(object_id, "cant_resolve_object") unless object.present?
           return process_failed(object_id, "object_not_supported") unless object.can_belong_to.include?(:remote)
@@ -181,6 +181,8 @@ module DiscourseActivityPub
           end
         else
           stored = case activity.type
+            when AP::Activity::Like.type
+              DiscourseActivityPubObject.find_by(ap_id: object_id)
             when AP::Activity::Follow.type
               DiscourseActivityPubActor.find_by(ap_id: object_id)
             when AP::Activity::Undo.type


### PR DESCRIPTION
@pmusaraj This will fix the Like bug you found. The development notes are:

- Match like spec object json to Mastodon like object json
- Add tests for both local and remote notes
- Fix issues arising from failing tests

Note that Mastodon does not process likes on statuses it's imported (i.e. what it considers to be a remote status). So it seems there's nothing we can do to make likes of posts originally made in Discourse show up as favourites in Mastodon. See https://github.com/mastodon/mastodon/blob/main/app/lib/activitypub/activity/like.rb#L7. Likes of posts originally made in Mastodon will show up as favourites in Mastodon, and we process Like activities coming from Mastodon (triggered by a favourite) for both local and remote Notes.