### PR TITLE
Create separate content parser

### DIFF
--- a/spec/lib/discourse_activity_pub/content_parser_spec.rb
+++ b/spec/lib/discourse_activity_pub/content_parser_spec.rb
@@ -46,5 +46,48 @@ RSpec.describe DiscourseActivityPub::ContentParser do
         expect(described_class.get_content(post)).to eq(described_class.cook(post.raw))
       end
     end
+
+    context "with Note" do
+      before do
+        Post.any_instance.stubs(:activity_pub_object_type).returns('Note')
+      end
+
+      context "with markdown" do
+        let(:raw_markdown) {
+          <<~STRING
+            # First Header
+
+            ## Second Header
+
+            ### Third Header
+
+            #### Fourth Header
+
+            Paragraph
+
+            [Link](https://discourse.org)
+          STRING
+        }
+        let(:cooked_markdown) {
+          <<~HTML
+            <h1>First Header</h1>
+            <h2>Second Header</h2>
+            <h3>Third Header</h3>
+            <h4>Fourth Header</h4>
+            Paragraph
+            <a href="https://discourse.org">Link</a>
+          HTML
+        }
+        let!(:post) { Fabricate(:post, raw: raw_markdown) }
+
+        before do
+          SiteSetting.activity_pub_note_excerpt_maxlength = 1000
+        end
+
+        it "returns html" do
+          expect(described_class.get_content(post)).to eq(cooked_markdown.strip)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
@pmusaraj This is to address the markdown / html issue reported on meta. A few notes on what I'm doing here:

1. I decided to bite the bullet and create an entirely separate parser (separate from the excerpt parser) to make it clear exactly what's supported and what's going on. This was going to happen at some point, and better sooner than later to help to clarify what's going on.

2. The immediate issue we are dealing with format-wise arose due to an incorrect handling of header markup (I hadn't included the right markdown rule to convert it to header tags). That issue, specifically as it was arising in posts coming from meta has been addressed.

3. Folks are already using Notes for long content that may involve a lot of markup. The best solution for long content is actually to federate an Article instead of a Note, as that just takes all the cooked HTML of a post. However Mastodon does not support showing the `content` of Articles (yet; it just shows a link currently).

4. When federating a Note, I think we should start from a relatively conservative base of supported markup and increment from there as appropriate. A Note is really meant to be short, simple, content, so I think this makes sense. Currently that's just `a` and `h*` elements.

Note that Mastodon converts `h*` tags to `strong`.