### PR TITLE
DEV: Refactor activity_pub_enabled source of truth

### DIFF
--- a/app/controllers/discourse_activity_pub/ap/objects_controller.rb
+++ b/app/controllers/discourse_activity_pub/ap/objects_controller.rb
@@ -30,7 +30,7 @@ class DiscourseActivityPub::AP::ObjectsController < ApplicationController
   end
 
   def ensure_site_enabled
-    render_activity_pub_error("not_enabled", 403) unless Site.activity_pub_enabled
+    render_activity_pub_error("not_enabled", 403) unless DiscourseActivityPub.enabled
   end
 
   def validate_headers

--- a/app/controllers/discourse_activity_pub/webfinger_controller.rb
+++ b/app/controllers/discourse_activity_pub/webfinger_controller.rb
@@ -28,7 +28,7 @@ module DiscourseActivityPub
     end
 
     def ensure_site_enabled
-      render_webfinger_error("not_enabled", 403) unless Site.activity_pub_enabled
+      render_webfinger_error("not_enabled", 403) unless DiscourseActivityPub.enabled
     end
 
     def render_webfinger_error(key, status)

--- a/app/jobs/discourse_activity_pub_deliver.rb
+++ b/app/jobs/discourse_activity_pub_deliver.rb
@@ -47,7 +47,7 @@ module Jobs
     end
 
     def perform_request?
-      Site.activity_pub_enabled &&
+      DiscourseActivityPub.enabled &&
         has_required_args? &&
         actors_ready? &&
         object_ready? &&

--- a/assets/javascripts/discourse/components/activity-pub-status.js
+++ b/assets/javascripts/discourse/components/activity-pub-status.js
@@ -28,7 +28,8 @@ export default class ActivityPubStatus extends Component {
       this.messageBus.subscribe("/activity-pub", this.handleMessage);
 
       if (this.forComposer && !this.args.model.activity_pub_visibility) {
-        this.args.model.activity_pub_visibility = this.category.activity_pub_default_visibility;
+        this.args.model.activity_pub_visibility =
+          this.category.activity_pub_default_visibility;
       }
     }
   }
@@ -61,7 +62,8 @@ export default class ActivityPubStatus extends Component {
     };
     if (this.active) {
       args.category_name = this.category.name;
-      args.delay_minutes = this.siteSettings.activity_pub_delivery_delay_minutes;
+      args.delay_minutes =
+        this.siteSettings.activity_pub_delivery_delay_minutes;
     }
     return I18n.t(
       `discourse_activity_pub.status.title.${this.translatedTitleKey}`,

--- a/extensions/discourse_activity_pub_guardian_extension.rb
+++ b/extensions/discourse_activity_pub_guardian_extension.rb
@@ -20,7 +20,7 @@ module DiscourseActivityPubGuardianExtension
   end
 
   def activity_pub_enabled_topic?
-    return false unless Site.activity_pub_enabled && request&.params["topic_id"]
+    return false unless DiscourseActivityPub.enabled && request&.params["topic_id"]
     topic = Topic.find_by(id: request.params["topic_id"].to_i)
     topic&.activity_pub_enabled
   end

--- a/extensions/discourse_activity_pub_site_extension.rb
+++ b/extensions/discourse_activity_pub_site_extension.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-module DiscourseActivityPubSiteExtension
-  def activity_pub_enabled
-    !SiteSetting.login_required && SiteSetting.activity_pub_enabled
-  end
-end

--- a/lib/discourse_activity_pub/engine.rb
+++ b/lib/discourse_activity_pub/engine.rb
@@ -19,4 +19,8 @@ module DiscourseActivityPub
   def self.base_url
     "https://#{host}#{Discourse.base_path}"
   end
+
+  def self.enabled
+    !SiteSetting.login_required && SiteSetting.activity_pub_enabled
+  end
 end

--- a/spec/lib/discourse_activity_pub/engine_spec.rb
+++ b/spec/lib/discourse_activity_pub/engine_spec.rb
@@ -1,14 +1,12 @@
-# frozen_string_literal: true
-
-RSpec.describe Site do
-  describe "#activity_pub_enabled" do
+RSpec.describe DiscourseActivityPub do
+  describe "#enabled" do
     context "without activity pub enabled" do
       before do
         SiteSetting.activity_pub_enabled = false
       end
 
       it "returns false" do
-        expect(Site.activity_pub_enabled).to eq(false)
+        expect(DiscourseActivityPub.enabled).to eq(false)
       end
     end
 
@@ -18,7 +16,7 @@ RSpec.describe Site do
       end
 
       it "returns true" do
-        expect(Site.activity_pub_enabled).to eq(true)
+        expect(DiscourseActivityPub.enabled).to eq(true)
       end
 
       context "with login required" do
@@ -27,7 +25,7 @@ RSpec.describe Site do
         end
 
         it "returns false" do
-          expect(Site.activity_pub_enabled).to eq(false)
+          expect(DiscourseActivityPub.enabled).to eq(false)
         end
       end
     end


### PR DESCRIPTION
@angusmcleod I noticed locally that I would often get this error when editing a locale file in a plugin (and possibly other edits) while the activity pub plugin was present: 

<img width="764" alt="image" src="https://github.com/discourse/discourse-activity-pub/assets/368961/6093d162-f96a-4641-88b6-f0607fee8f09">

I think the issue happens because the site serializer gets invoked before the plugin has prepended the `activity_pub_enabled` method to the site module. This is likely a race condition limited to dev server, but it's quite annoying, it tends to happen often and requires a full server restart. (I'm not sure whether you're seeing the same issue locally, I am on macOS and start my local servers via `bin/ember-cli -u`, which starts both an Ember proxy and Unicorn).

The proposed solution avoids prepending to the Site module but keeps the site serializer. I'm not sure whether we need to keep the site serializer to be honest, it doesn't seem like the best place for this information. It kinda leaks the status of the plugin to anonymous users as well (via `site.json`). We could also add a frontend "single source of truth" that keeps track of the two site settings, it might be a bit of a compromise, but it may feel cleaner. 