### PR TITLE
PERF: avoid N+1, skip unused serializer method

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -290,9 +290,6 @@ after_initialize do
   add_to_class(:topic, :activity_pub_summary) do
     title
   end
-  add_to_serializer(:topic_view, :activity_pub_enabled) do
-    object.topic.activity_pub_enabled
-  end
 
   Post.has_one :activity_pub_object,
                class_name: "DiscourseActivityPubObject",
@@ -332,8 +329,6 @@ after_initialize do
   end
   add_to_class(:post, :activity_pub_enabled) do
     return false unless DiscourseActivityPub.enabled
-
-    topic = Topic.with_deleted.find_by(id: self.topic_id)
     return false unless topic&.activity_pub_enabled
 
     is_first_post? || activity_pub_full_topic

--- a/spec/serializers/discourse_activity_pub/ap/object/note_serializer_spec.rb
+++ b/spec/serializers/discourse_activity_pub/ap/object/note_serializer_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe DiscourseActivityPub::AP::Object::NoteSerializer do
   let!(:category) { Fabricate(:category) }
   let!(:topic) { Fabricate(:topic, category: category) }
-  let!(:post) { PostCreator.create!(Discourse.system_user, raw: "Post content", topic_id: topic.id) }
+  let!(:post) { Fabricate(:post, topic: topic, raw: "Post content") }
 
   before do
     toggle_activity_pub(category, callbacks: true)


### PR DESCRIPTION
Noticed some performance issues on one instance, I suspect these two changes are a partial fix. 

- we don't need to load a fresh topic in `Post.activity_pub_enabled`, it's already available, and loading the topic adds a lot of queries to the topic/show route (on a local topic with 2 posts, I get 138 vs 158 queries logged by mini-profiler)
- `topic_view.activity_pub_enabled` doesn't seem to be used anywhere

