### PR TITLE
PERF: Improve topic serialization performance

### DIFF
--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe ListController do
+  describe "#index" do
+    context "with activity pub topics" do
+      fab!(:category1) { Fabricate(:category) }
+      fab!(:category2) { Fabricate(:category) }
+      fab!(:category3) { Fabricate(:category) }
+      fab!(:topic_ids) {
+        topic_ids = []
+        [category1, category2].each do |category|
+          5.times do
+            topic = Fabricate(:topic, category: category)
+            topic_ids << topic.id
+            collection = Fabricate(:discourse_activity_pub_ordered_collection, model: topic)
+            post = Fabricate(:post, topic: topic)
+            note = Fabricate(:discourse_activity_pub_object_note, model: post, collection_id: collection.id)
+            activity = Fabricate(:discourse_activity_pub_activity_create, object: note)
+          end
+        end
+        topic_ids
+      }
+
+      def track_index_queries
+        track_sql_queries do
+          get "/latest.json"
+          expect(response.status).to eq(200)
+          body = response.parsed_body
+          expect(body["topic_list"]["topics"].map { |t| t["id"] }).to contain_exactly(*topic_ids)
+        end
+      end
+
+      context "without a logged in user" do
+        it "does not increase the number of queries" do
+          SiteSetting.activity_pub_enabled = false
+
+          # prime caches
+          get "/latest.json"
+          expect(response.status).to eq(200)
+
+          disabled_queries = track_index_queries
+
+          SiteSetting.activity_pub_enabled = true
+          toggle_activity_pub(category1, callbacks: true)
+          toggle_activity_pub(category2, callbacks: true)
+
+          enabled_queries = track_index_queries
+
+          expect(enabled_queries.count).to eq(disabled_queries.count)
+        end
+      end
+
+      context "with a logged in user" do
+        let!(:user) { Fabricate(:user) }
+
+        before do
+          sign_in(user)
+        end
+
+        it "does not increase the number of queries" do
+          SiteSetting.activity_pub_enabled = false
+
+          # prime caches
+          get "/latest.json"
+          expect(response.status).to eq(200)
+
+          disabled_queries = track_index_queries
+
+          SiteSetting.activity_pub_enabled = true
+          toggle_activity_pub(category1, callbacks: true)
+          toggle_activity_pub(category2, callbacks: true)
+
+          enabled_queries = track_index_queries
+
+          expect(enabled_queries.count).to eq(disabled_queries.count)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe TopicsController do
+  ADDITIONAL_QUERY_LIMIT = 6
+
+  describe "#show" do
+    fab!(:category) { Fabricate(:category) }
+    fab!(:topic) { Fabricate(:topic, category: category) }
+    fab!(:collection) { Fabricate(:discourse_activity_pub_ordered_collection, model: topic) }
+    fab!(:posts) {
+      posts = []
+      10.times do
+        post = Fabricate(:post, topic: topic)
+        posts << post
+        note = Fabricate(:discourse_activity_pub_object_note, model: post, collection_id: collection.id)
+        Fabricate(:discourse_activity_pub_activity_create, object: note)
+      end
+      posts
+    }
+
+    def track_topic_show_queries
+      track_sql_queries do
+        get "/t/#{topic.id}.json"
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "without a logged in user" do
+      context "with activity pub first_post enabled" do
+        it "does not increase the number of queries beyond the limit" do
+          SiteSetting.activity_pub_enabled = false
+
+          get "/t/#{topic.id}.json"
+          expect(response.status).to eq(200)
+
+          disabled_queries = track_topic_show_queries
+
+          SiteSetting.activity_pub_enabled = true
+          toggle_activity_pub(category, callbacks: true, publication_type: 'first_post')
+
+          enabled_queries = track_topic_show_queries
+          expect(enabled_queries.count).to be <= (disabled_queries.count + ADDITIONAL_QUERY_LIMIT)
+        end
+      end
+
+      context "with activity pub full_topic enabled" do
+        it "does not increase the number of queries beyond the limit" do
+          SiteSetting.activity_pub_enabled = false
+
+          get "/t/#{topic.id}.json"
+          expect(response.status).to eq(200)
+
+          disabled_queries = track_topic_show_queries
+
+          SiteSetting.activity_pub_enabled = true
+          toggle_activity_pub(category, callbacks: true, publication_type: 'full_topic')
+
+          enabled_queries = track_topic_show_queries
+          expect(enabled_queries.count).to be <= (disabled_queries.count + ADDITIONAL_QUERY_LIMIT)
+        end
+      end
+    end
+
+    context "with a logged in user" do
+      let!(:user) { Fabricate(:user) }
+
+      before do
+        sign_in(user)
+      end
+
+      context "with activity pub first_post enabled" do
+        it "does not increase the number of queries beyond the limit" do
+          SiteSetting.activity_pub_enabled = false
+
+          get "/t/#{topic.id}.json"
+          expect(response.status).to eq(200)
+
+          disabled_queries = track_topic_show_queries
+
+          SiteSetting.activity_pub_enabled = true
+          toggle_activity_pub(category, callbacks: true, publication_type: 'first_post')
+
+          enabled_queries = track_topic_show_queries
+
+          expect(enabled_queries.count).to be <= (disabled_queries.count + ADDITIONAL_QUERY_LIMIT)
+        end
+      end
+
+      context "with activity pub full_topic enabled" do
+        it "does not increase the number of queries beyond the limit" do
+          SiteSetting.activity_pub_enabled = false
+
+          get "/t/#{topic.id}.json"
+          expect(response.status).to eq(200)
+
+          disabled_queries = track_topic_show_queries
+
+          SiteSetting.activity_pub_enabled = true
+          toggle_activity_pub(category, callbacks: true, publication_type: 'full_topic')
+
+          enabled_queries = track_topic_show_queries
+          expect(enabled_queries.count).to be <= (disabled_queries.count + ADDITIONAL_QUERY_LIMIT)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
@pmusaraj This is the first of a few performance related PRs. This one is focused on topics.

The next one will likely be focused on categories, and will come after https://github.com/discourse/discourse/pull/23969 is merged. I'm going to circle back to topics again after this is and the first categories performance PR is handled to see what additional gains can be made.

Note that all the actual performance gains here are being made in the topic `show` action. The AP plugin seems to have little discernible impact on topic lists (category lists are a different story) and I've added a spec to both (partially) demonstrate that and also as a guard against regression.

With respect to topic `show` I'll let the specs speak for themselves, but just to illustrate the gain being made there (and as a sanity check) these are the different profiles of a topic on my local. The topic has:
- Full Topic publication type (when AP is enabled)
- 7 posts from 4 different actors (users)

##### No AP plugin (vanilla discourse)
<img width="741" alt="Screenshot 2023-10-19 at 14 16 28" src="https://github.com/discourse/discourse-activity-pub/assets/5931623/bd3be390-56f1-4d2e-a0dd-68365647552f">

##### AP plugin on this branch
<img width="730" alt="Screenshot 2023-10-19 at 14 12 32" src="https://github.com/discourse/discourse-activity-pub/assets/5931623/45555532-fcbd-4b0b-a24a-26e330ff0d59">

##### AP plugin on main
<img width="733" alt="Screenshot 2023-10-19 at 14 14 21" src="https://github.com/discourse/discourse-activity-pub/assets/5931623/fbcd3b7b-2027-42f0-ac50-d3e8089e3763">

