### PR TITLE
Icon to avatar update improvements

### DIFF
--- a/lib/discourse_activity_pub/user_handler.rb
+++ b/lib/discourse_activity_pub/user_handler.rb
@@ -123,7 +123,7 @@ module DiscourseActivityPub
     protected
 
     def update_avatar_from_icon
-      if actor.icon_url
+      if update_avatar?
         icon_upload = Upload.find_by(user_id: user.id, origin: actor.icon_url)
 
         if !icon_upload
@@ -139,6 +139,16 @@ module DiscourseActivityPub
 
       prefix = "Failed to #{verb} user for #{actor.id}"
       Rails.logger.warn("[Discourse Activity Pub] #{prefix}: #{message}")
+    end
+
+    def update_avatar?
+      return false unless actor.icon_url
+      return true if !user || user.user_avatar.custom_upload.blank?
+
+      DiscourseActivityPub::URI.matching_hosts?(
+        actor.icon_url,
+        user.user_avatar.custom_upload.origin
+      )
     end
   end
 end

--- a/lib/discourse_activity_pub/user_handler.rb
+++ b/lib/discourse_activity_pub/user_handler.rb
@@ -143,11 +143,11 @@ module DiscourseActivityPub
 
     def update_avatar?
       return false unless actor.icon_url
-      return true if !user || user.user_avatar.custom_upload.blank?
+      return true if !user || user.uploaded_avatar.blank?
 
       DiscourseActivityPub::URI.matching_hosts?(
         actor.icon_url,
-        user.user_avatar.custom_upload.origin
+        user.uploaded_avatar.origin
       )
     end
   end

--- a/spec/lib/discourse_activity_pub/user_handler_spec.rb
+++ b/spec/lib/discourse_activity_pub/user_handler_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DiscourseActivityPub::UserHandler do
     end
 
     context "when actor has user" do
-      let(:user) { Fabricate(:user) }
+      let!(:user) { Fabricate(:user) }
 
       before do
         actor.update(model_id: user.id, model_type: 'User')
@@ -42,25 +42,69 @@ RSpec.describe DiscourseActivityPub::UserHandler do
     end
 
     context "when actor has icon" do
+      fab!(:external_origin) { 'https://external.com' }
+
       before do
-        actor.icon_url = "logo.png"
+        actor.icon_url = "#{external_origin}/logo.png"
         actor.save
         FileHelper.stubs(:download).returns(file_from_fixtures("logo.png"))
       end
 
-      it "downloads and sets an icon as user's avatar" do
-        user = described_class.update_or_create_user(actor)
-        expect(user.user_avatar.custom_upload.origin).to eq("logo.png")
+      context "when the actor has a user" do
+        fab!(:user) { Fabricate(:user) }
+
+        before do
+          actor.update(model_id: user.id, model_type: 'User')
+        end
+
+        context "when the user has a custom avatar" do
+          fab!(:custom_avatar_url) { "/images/avatar.png" }
+          fab!(:custom_avatar) { Fabricate(:upload, url: custom_avatar_url) }
+
+          before do
+            user.user_avatar.update(custom_upload_id: custom_avatar.id)
+          end
+
+          it "does not set the icon as the user's avatar" do
+            described_class.update_or_create_user(actor)
+            expect(user.user_avatar.custom_upload.url).to eq(custom_avatar_url)
+          end
+
+          it "does not update the user's avatar if the icon changes" do
+            described_class.update_or_create_user(actor)
+            expect(user.user_avatar.custom_upload.url).to eq(custom_avatar_url)
+
+            FileHelper.stubs(:download).returns(file_from_fixtures("logo-dev.png"))
+            actor.icon_url = "#{external_origin}/logo-dev.png"
+            actor.save
+            described_class.update_or_create_user(actor)
+            expect(user.user_avatar.custom_upload.url).to eq(custom_avatar_url)
+          end
+        end
+
+        context "when the user does not have a custom avatar" do
+          it "downloads and sets the icon as the user's avatar" do
+            described_class.update_or_create_user(actor)
+            expect(user.user_avatar.custom_upload.origin).to eq("#{external_origin}/logo.png")
+          end
+
+          it "updates user's avatar if the icon changes" do
+            described_class.update_or_create_user(actor)
+
+            FileHelper.stubs(:download).returns(file_from_fixtures("logo-dev.png"))
+            actor.icon_url = "#{external_origin}/logo-dev.png"
+            actor.save
+            described_class.update_or_create_user(actor)
+            expect(user.user_avatar.custom_upload.origin).to eq("#{external_origin}/logo-dev.png")
+          end
+        end
       end
 
-      it "updates user's avatar if icon changes" do
-        described_class.update_or_create_user(actor)
-
-        FileHelper.stubs(:download).returns(file_from_fixtures("logo-dev.png"))
-        actor.icon_url = "logo-dev.png"
-        actor.save
-        user = described_class.update_or_create_user(actor)
-        expect(user.user_avatar.custom_upload.origin).to eq("logo-dev.png")
+      context "when the actor does not have a user" do
+        it "downloads and sets the icon as the user's avatar" do
+          user = described_class.update_or_create_user(actor)
+          expect(user.user_avatar.custom_upload.origin).to eq("#{external_origin}/logo.png")
+        end
       end
     end
   end


### PR DESCRIPTION
Only update avatar if
- gravatar not set; and
- custom avatar not set; or
- custom avatar origin is same as actor icon origin (i.e. avatar was originally set from actor icon)