### PR TITLE
Support different activity and object actors

### DIFF
--- a/app/models/discourse_activity_pub_object.rb
+++ b/app/models/discourse_activity_pub_object.rb
@@ -79,6 +79,10 @@ class DiscourseActivityPubObject < ActiveRecord::Base
     @to ||= activities.first.present? ? activities.first.to : public_collection_id
   end
 
+  def attributed_to
+    @attributed_to ||= model&.activity_pub_actor&.ap_id
+  end
+
   def likes_collection
     @likes_collection ||= begin
       collection = DiscourseActivityPubCollection.new(

--- a/app/serializers/discourse_activity_pub/ap/object_serializer.rb
+++ b/app/serializers/discourse_activity_pub/ap/object_serializer.rb
@@ -6,7 +6,8 @@ class DiscourseActivityPub::AP::ObjectSerializer < ActiveModel::Serializer
              :to,
              :published,
              :updated,
-             :url
+             :url,
+             :attributedTo
 
   def attributes(*args)
     hash = super
@@ -36,5 +37,13 @@ class DiscourseActivityPub::AP::ObjectSerializer < ActiveModel::Serializer
 
   def include_url?
     object.url.present?
+  end
+
+  def attributedTo
+    object.attributed_to
+  end
+
+  def include_attributedTo?
+    object.attributed_to.present?
   end
 end

--- a/extensions/discourse_activity_pub_guardian_extension.rb
+++ b/extensions/discourse_activity_pub_guardian_extension.rb
@@ -9,11 +9,6 @@ module DiscourseActivityPubGuardianExtension
     super
   end
 
-  def can_wiki?(post)
-    return false if post.activity_pub_enabled
-    super
-  end
-
   def can_change_post_owner?
     return false if activity_pub_enabled_topic?
     super

--- a/lib/discourse_activity_pub/ap/object.rb
+++ b/lib/discourse_activity_pub/ap/object.rb
@@ -62,6 +62,10 @@ module DiscourseActivityPub
         stored&.respond_to?(:published_at) && stored.published_at&.iso8601
       end
 
+      def attributed_to
+        stored&.respond_to?(:attributed_to) && stored.attributed_to
+      end
+
       def self.type
         self.new.type
       end

--- a/lib/discourse_activity_pub/json_ld.rb
+++ b/lib/discourse_activity_pub/json_ld.rb
@@ -86,7 +86,7 @@ module DiscourseActivityPub
       return nil if value.nil?
       return value if value.is_a?(String)
       return value['url'] if value.is_a?(Hash)
-      return value.first['url'] if value.is_a?(Array)
+      value.first['url'] if value.is_a?(Array)
     end
 
     def publicly_addressed?(json)

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -53,30 +53,6 @@ RSpec.describe Guardian do
     end
   end
 
-  describe "can_wiki?" do
-    describe "a Post" do
-      context "with activity pub enabled" do
-        before do
-          toggle_activity_pub(category, callbacks: true)
-        end
-
-        it "returns false for all users" do
-          expect(Guardian.new(admin).can_wiki?(post)).to be_falsey
-          expect(Guardian.new(user).can_wiki?(post)).to be_falsey
-          expect(Guardian.new(another_user).can_wiki?(post)).to be_falsey
-        end
-      end
-
-      context "with activity pub disabled" do
-        it "returns true for the right users" do
-          expect(Guardian.new(admin).can_wiki?(post)).to be_truthy
-          expect(Guardian.new(user).can_wiki?(post)).to be_falsey
-          expect(Guardian.new(another_user).can_wiki?(post)).to be_falsey
-        end
-      end
-    end
-  end
-
   describe "can_change_post_owner?" do
     describe "a Post" do
       context "with a change owner request" do

--- a/spec/serializers/discourse_activity_pub/ap/object/note_serializer_spec.rb
+++ b/spec/serializers/discourse_activity_pub/ap/object/note_serializer_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe DiscourseActivityPub::AP::Object::NoteSerializer do
-  let!(:category) { Fabricate(:category) }
-  let!(:topic) { Fabricate(:topic, category: category) }
-  let!(:post) { Fabricate(:post, topic: topic, raw: "Post content") }
+  fab!(:category) { Fabricate(:category) }
+  fab!(:topic) { Fabricate(:topic, category: category) }
+  fab!(:post) { Fabricate(:post, topic: topic, raw: "Post content") }
+  fab!(:post_creator_actor) { Fabricate(:discourse_activity_pub_actor_person, model: post.user, local: true) }
 
   before do
     toggle_activity_pub(category, callbacks: true)
-    @note = Fabricate(:discourse_activity_pub_object_note, model: post)
   end
 
   context "with link to forum enabled" do
@@ -16,9 +16,10 @@ RSpec.describe DiscourseActivityPub::AP::Object::NoteSerializer do
     end
 
     it "serializes note content with a link to the forum" do
+      note = Fabricate(:discourse_activity_pub_object_note, model: post, local: true)
       link_text = I18n.t("discourse_activity_pub.object.note.link_to_forum")
-      link_html = "<a href=\"#{@note.model.activity_pub_url}\">#{link_text}</a>"
-      expect(@note.ap.json[:content]).to eq("#{@note.content}<br><br>#{link_html}")
+      link_html = "<a href=\"#{note.model.activity_pub_url}\">#{link_text}</a>"
+      expect(note.ap.json[:content]).to eq("#{note.content}<br><br>#{link_html}")
     end
   end
 
@@ -28,7 +29,27 @@ RSpec.describe DiscourseActivityPub::AP::Object::NoteSerializer do
     end
 
     it "serializes note content without a link to the forum" do
-      expect(@note.ap.json[:content]).to eq(@note.content)
+      note = Fabricate(:discourse_activity_pub_object_note, model: post, local: true)
+      expect(note.ap.json[:content]).to eq(note.content)
+    end
+  end
+
+  context "with first_post enabled" do
+    it "serializes attributedTo as the category actor" do
+      note = Fabricate(:discourse_activity_pub_object_note, model: post, local: true)
+      expect(note.ap.json[:attributedTo]).to eq(category.activity_pub_actor.ap_id)
+    end
+  end
+
+  context "with full_topic enabled" do
+    before do
+      toggle_activity_pub(category, callbacks: true, publication_type: 'full_topic')
+      post.topic.create_activity_pub_collection!
+    end
+
+    it "serializes attributedTo as the post creator actor" do
+      note = Fabricate(:discourse_activity_pub_object_note, model: post, local: true)
+      expect(note.ap.json[:attributedTo]).to eq(post_creator_actor.ap_id)
     end
   end
 end


### PR DESCRIPTION
@pmusaraj A pre-requisite to supporting advanced edit scenarios (e.g. wikis) is to allow for different activity and object actors. The object "actor" is represented in the [`attributedTo` property](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-attributedto).

The reason this is in draft is that Mastodon does not currently support having a different `Update` actor from the original status actor. If we were to merge this, we'd be compliant with the relevant specifications (i.e. ActivityStreams), however edits from staff would not be processed by Mastodon. I've opened a PR to Mastodon to add support for this, so we'll need to wait to see what happens there: https://github.com/mastodon/mastodon/pull/27524

Note that I've already tested running both Discourse and Mastodon with both branches, and this works, i.e. edits from staff in Discourse show up as edits from the appropriate actors in Mastodon, i.e.

<img width="231" alt="Screenshot 2023-10-24 at 15 50 36" src="https://github.com/discourse/discourse-activity-pub/assets/5931623/b6215826-958d-42f2-b034-dfb879542d4f">
