### PR TITLE
Category serialization improvements

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -211,49 +211,51 @@ after_initialize do
     end
   end
 
-  add_to_serializer(:basic_category, :activity_pub_enabled) do
-    object.activity_pub_enabled
-  end
   add_to_serializer(
     :basic_category,
+    :activity_pub_enabled
+  ) { object.activity_pub_enabled }
+  add_to_serializer(
+    :site_category,
     :activity_pub_ready,
     include_condition: -> { object.activity_pub_enabled }
   ) { object.activity_pub_ready? }
-  add_to_serializer(
-    :basic_category,
-    :activity_pub_username,
-    include_condition: -> { object.activity_pub_enabled }
-  ) { object.activity_pub_username }
-  add_to_serializer(
-    :basic_category,
-    :activity_pub_name,
-    include_condition: -> { object.activity_pub_enabled }
-  ) { object.activity_pub_name }
-  add_to_serializer(
-    :basic_category,
-    :activity_pub_show_status,
-    include_condition: -> { object.activity_pub_enabled }
-  ) { object.activity_pub_show_status }
-  add_to_serializer(
-    :basic_category,
-    :activity_pub_show_handle,
-    include_condition: -> { object.activity_pub_enabled }
-  ) { object.activity_pub_show_handle }
-  add_to_serializer(
-    :basic_category,
-    :activity_pub_default_visibility,
-    include_condition: -> { object.activity_pub_enabled }
-  ) { object.activity_pub_default_visibility }
 
   if Site.respond_to? :preloaded_category_custom_fields
     Site.preloaded_category_custom_fields << "activity_pub_enabled"
     Site.preloaded_category_custom_fields << "activity_pub_ready"
-    Site.preloaded_category_custom_fields << "activity_pub_show_status"
-    Site.preloaded_category_custom_fields << "activity_pub_show_handle"
-    Site.preloaded_category_custom_fields << "activity_pub_username"
-    Site.preloaded_category_custom_fields << "activity_pub_name"
-    Site.preloaded_category_custom_fields << "activity_pub_default_visibility"
-    Site.preloaded_category_custom_fields << "activity_pub_publication_type"
+  end
+
+  register_modifier(:site_all_categories_cache_query) do |query|
+    query.includes(:activity_pub_actor)
+  end
+
+  if self.respond_to?(:register_category_list_preloaded_category_custom_fields)
+    register_category_list_preloaded_category_custom_fields("activity_pub_enabled")
+  end
+
+  serialized_category_custom_fields = %w(
+    activity_pub_show_status
+    activity_pub_show_handle
+    activity_pub_username
+    activity_pub_name
+    activity_pub_default_visibility
+    activity_pub_publication_type
+  )
+  serialized_category_custom_fields.each do |field|
+    add_to_serializer(
+      :basic_category,
+      field.to_sym,
+      include_condition: -> { object.activity_pub_enabled }
+    ) { object.send(field) }
+
+    if Site.respond_to? :preloaded_category_custom_fields
+      Site.preloaded_category_custom_fields << field
+    end
+
+    if self.respond_to?(:register_category_list_preloaded_category_custom_fields)
+      register_category_list_preloaded_category_custom_fields(field)
+    end
   end
 
   Topic.has_one :activity_pub_object,

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe CategoriesController do
+  describe "#index" do
+    context "with activity pub categories" do
+      let!(:category1) { Fabricate(:category) }
+      let!(:category2) { Fabricate(:category) }
+      let!(:category3) { Fabricate(:category) }
+
+      it "does not increase the number of queries" do
+        SiteSetting.activity_pub_enabled = false
+        # prime caches
+        get "/categories.json"
+        expect(response.status).to eq(200)
+
+        disabled_queries =
+          track_sql_queries do
+            get "/categories.json"
+            expect(response.status).to eq(200)
+          end
+
+        SiteSetting.activity_pub_enabled = true
+        toggle_activity_pub(category1, callbacks: true)
+        toggle_activity_pub(category2, callbacks: true)
+
+        enabled_queries =
+          track_sql_queries do
+            get "/categories.json"
+            expect(response.status).to eq(200)
+          end
+
+        expect(enabled_queries.count).to eq(disabled_queries.count)
+      end
+
+      context "when topics are loaded" do
+        before do
+          [category1, category2].each do |category|
+            5.times do
+              topic = Fabricate(:topic, category: category)
+              collection = Fabricate(:discourse_activity_pub_ordered_collection, model: topic)
+              post = Fabricate(:post, topic: topic)
+              note = Fabricate(:discourse_activity_pub_object_note, model: post, collection_id: collection.id)
+              activity = Fabricate(:discourse_activity_pub_activity_create, object: note)
+            end
+          end
+
+          CategoryFeaturedTopic.feature_topics
+          SiteSetting.desktop_category_page_style = "categories_with_featured_topics"
+        end
+
+        it "does not increase the number of queries" do
+          SiteSetting.activity_pub_enabled = false
+          # prime caches
+          get "/categories.json"
+          expect(response.status).to eq(200)
+
+          disabled_queries =
+            track_sql_queries do
+              get "/categories.json"
+              expect(response.status).to eq(200)
+            end
+
+          SiteSetting.activity_pub_enabled = true
+          toggle_activity_pub(category1, callbacks: true)
+          toggle_activity_pub(category2, callbacks: true)
+
+          enabled_queries =
+            track_sql_queries do
+              get "/categories.json"
+              expect(response.status).to eq(200)
+            end
+
+          expect(enabled_queries.count).to eq(disabled_queries.count)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -7,47 +7,7 @@ RSpec.describe CategoriesController do
       let!(:category2) { Fabricate(:category) }
       let!(:category3) { Fabricate(:category) }
 
-      it "does not increase the number of queries" do
-        SiteSetting.activity_pub_enabled = false
-        # prime caches
-        get "/categories.json"
-        expect(response.status).to eq(200)
-
-        disabled_queries =
-          track_sql_queries do
-            get "/categories.json"
-            expect(response.status).to eq(200)
-          end
-
-        SiteSetting.activity_pub_enabled = true
-        toggle_activity_pub(category1, callbacks: true)
-        toggle_activity_pub(category2, callbacks: true)
-
-        enabled_queries =
-          track_sql_queries do
-            get "/categories.json"
-            expect(response.status).to eq(200)
-          end
-
-        expect(enabled_queries.count).to eq(disabled_queries.count)
-      end
-
-      context "when topics are loaded" do
-        before do
-          [category1, category2].each do |category|
-            5.times do
-              topic = Fabricate(:topic, category: category)
-              collection = Fabricate(:discourse_activity_pub_ordered_collection, model: topic)
-              post = Fabricate(:post, topic: topic)
-              note = Fabricate(:discourse_activity_pub_object_note, model: post, collection_id: collection.id)
-              activity = Fabricate(:discourse_activity_pub_activity_create, object: note)
-            end
-          end
-
-          CategoryFeaturedTopic.feature_topics
-          SiteSetting.desktop_category_page_style = "categories_with_featured_topics"
-        end
-
+      shared_examples "performance" do
         it "does not increase the number of queries" do
           SiteSetting.activity_pub_enabled = false
           # prime caches
@@ -72,6 +32,27 @@ RSpec.describe CategoriesController do
 
           expect(enabled_queries.count).to eq(disabled_queries.count)
         end
+      end
+
+      include_examples "performance"
+
+      context "when topics are loaded" do
+        before do
+          [category1, category2].each do |category|
+            5.times do
+              topic = Fabricate(:topic, category: category)
+              collection = Fabricate(:discourse_activity_pub_ordered_collection, model: topic)
+              post = Fabricate(:post, topic: topic)
+              note = Fabricate(:discourse_activity_pub_object_note, model: post, collection_id: collection.id)
+              activity = Fabricate(:discourse_activity_pub_activity_create, object: note)
+            end
+          end
+
+          CategoryFeaturedTopic.feature_topics
+          SiteSetting.desktop_category_page_style = "categories_with_featured_topics"
+        end
+
+        include_examples "performance"
       end
     end
   end

--- a/spec/requests/site_controller_spec.rb
+++ b/spec/requests/site_controller_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe SiteController do
+  describe "#site" do
+    context "with activity pub categories" do
+      let!(:category1) { Fabricate(:category) }
+      let!(:category2) { Fabricate(:category) }
+      let!(:category3) { Fabricate(:category) }
+
+      context "with a user" do
+        let!(:user) { Fabricate(:user) }
+
+        before do
+          sign_in(user)
+        end
+
+        it "does not increase the number of queries" do
+          SiteSetting.activity_pub_enabled = false
+
+          get "/site.json"
+          expect(response.status).to eq(200)
+
+          # This is needed to balance the cache clearing that occurs when
+          # the categories are saved (below).
+          Site.clear_cache
+
+          disabled_queries =
+            track_sql_queries do
+              get "/site.json"
+              expect(response.status).to eq(200)
+            end
+
+          SiteSetting.activity_pub_enabled = true
+          toggle_activity_pub(category1, callbacks: true)
+          toggle_activity_pub(category2, callbacks: true)
+
+          enabled_queries =
+            track_sql_queries do
+              get "/site.json"
+              expect(response.status).to eq(200)
+            end
+
+          expect(enabled_queries.count).to eq(disabled_queries.count)
+        end
+      end
+
+      context "without a user" do
+        it "does not increase the number of queries" do
+          SiteSetting.activity_pub_enabled = false
+
+          get "/site.json"
+          expect(response.status).to eq(200)
+
+          # This is needed to balance the cache clearing that occurs when
+          # the categories are saved (below).
+          Site.clear_anon_cache!
+          Site.clear_cache
+
+          disabled_queries =
+            track_sql_queries do
+              get "/site.json"
+              expect(response.status).to eq(200)
+            end
+
+          SiteSetting.activity_pub_enabled = true
+          toggle_activity_pub(category1, callbacks: true)
+          toggle_activity_pub(category2, callbacks: true)
+
+          Site.clear_anon_cache!
+
+          enabled_queries =
+            track_sql_queries do
+              get "/site.json"
+              expect(response.status).to eq(200)
+            end
+
+          expect(enabled_queries.count).to eq(disabled_queries.count)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Preload custom fields in the CategoryList.
- Don't load activity_pub_ready? outside of site category serializer (so we don't unnecessarily check for the presence of the activity_pub_actor).
- Preload activity_pub_actors for the site category serializer.
- Add specs to ensure the above is having the intended effect.