### PR TITLE
DEV: Change settings root from plugins: to discourse_activity_pub

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_activity_pub: "Discourse Activity Pub"
   js:
     category:
       discourse_activity_pub:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_activity_pub:
   activity_pub_enabled:
     default: true
     client: true


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.