### PR TITLE
DEV: Add meta_topic_id to plugin.rb

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -4,6 +4,7 @@
 # about: ActivityPub plugin for Discourse
 # version: 0.1.0
 # authors: Angus McLeod
+# meta_topic_id: 266794
 
 register_asset "stylesheets/common/common.scss"
 register_svg_icon "discourse-activity-pub"


### PR DESCRIPTION
We are doing this for all plugins so the link is correct
in the plugin list, this one will link to
https://meta.discourse.org/t/activitypub-plugin/266794
