### PR TITLE
DEV: Fix minor styling issues

### DIFF
--- a/assets/javascripts/discourse/components/activity-pub-follow-domain.hbs
+++ b/assets/javascripts/discourse/components/activity-pub-follow-domain.hbs
@@ -1,6 +1,6 @@
 <div class="activity-pub-follow-domain">
-  <label>{{i18n 'discourse_activity_pub.follow.domain.label'}}</label>
-  <div class="activity-pub-follow-domain-controls">
+  <label>{{i18n "discourse_activity_pub.follow.domain.label"}}</label>
+  <div class="activity-pub-follow-domain-controls inline-form">
     <Input
       id="activity_pub_follow_domain_input"
       @value={{this.domain}}
@@ -20,9 +20,9 @@
     {{#if this.error}}
       {{this.error}}
     {{else if this.verifying}}
-      {{i18n 'discourse_activity_pub.follow.domain.verifying'}}
+      {{i18n "discourse_activity_pub.follow.domain.verifying"}}
     {{else}}
-      {{i18n 'discourse_activity_pub.follow.domain.description'}}
+      {{i18n "discourse_activity_pub.follow.domain.description"}}
     {{/if}}
   </div>
 </div>

--- a/assets/javascripts/discourse/components/activity-pub-handle.hbs
+++ b/assets/javascripts/discourse/components/activity-pub-handle.hbs
@@ -6,19 +6,19 @@
         href={{@actor.url}}
         target="_blank"
         rel="noopener noreferrer"
-        class="btn btn-icon no-text"
+        class="btn btn-icon no-text btn-flat"
       >{{d-icon "external-link-alt"}}</a>
     {{/if}}
     {{#if this.copied}}
       <DButton
-        @class="btn-hover"
+        @class="btn-hover btn-flat"
         @icon="copy"
         @label="ip_lookup.copied"
       />
     {{else}}
       <DButton
         @action={{action "copy"}}
-        @class="no-text"
+        @class="no-text btn-flat"
         @icon="copy"
       />
     {{/if}}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1,6 +1,4 @@
-@import "common/components/buttons";
-
-@mixin description-text {
+@mixin ap-description-text {
   color: var(--primary-medium);
   margin-top: 4px;
   margin-bottom: 10px;
@@ -54,7 +52,7 @@ div.activity-pub-status {
   }
 
   .activity-pub-setting-description {
-    @include description-text;
+    @include ap-description-text;
   }
 
   .activity-pub-setting-notice {
@@ -101,15 +99,10 @@ div.activity-pub-status {
     overflow: hidden;
     white-space: nowrap;
   }
-
-  button,
-  a {
-    @extend .btn-flat;
-  }
 }
 
 .activity-pub-handle-description {
-  @include description-text;
+  @include ap-description-text;
 }
 
 .activity-pub-discovery-dropdown {
@@ -285,15 +278,10 @@ body.user-preferences-activity-pub-page {
 
 .activity-pub-follow-domain-controls {
   display: flex;
-  align-items: center;
-
-  input {
-    margin: 0;
-  }
 }
 
 .activity-pub-follow-domain-footer {
-  @include description-text;
+  @include ap-description-text;
 
   &.error {
     color: var(--danger);


### PR DESCRIPTION
Issue 1: Importing `common/components/buttons` makes those styles re-apply above other overrides (for example, overrides from other plugins).

Issue 2: Use core's `inline-form` for input/button alignment.

Issue 3: Add `ap-` to a mixin, to avoid potential future collisions.