### PR TITLE
FIX: Ensure local objects are resolved locally

### DIFF
--- a/app/models/discourse_activity_pub_actor.rb
+++ b/app/models/discourse_activity_pub_actor.rb
@@ -144,7 +144,7 @@ class DiscourseActivityPubActor < ActiveRecord::Base
     opts = {
       username: handle.username
     }
-    opts[:local] = true if local
+    opts[:local] = local ? true : [false, nil]
     opts[:domain] = handle.domain if !local
     opts[:ap_type] = types if types.present?
     actor = DiscourseActivityPubActor.find_by(opts)
@@ -162,7 +162,7 @@ class DiscourseActivityPubActor < ActiveRecord::Base
     opts = {
       ap_id: ap_id
     }
-    opts[:local] = true if local
+    opts[:local] = local ? true : [false, nil]
     actor = DiscourseActivityPubActor.find_by(opts)
 
     if (refresh || !actor) && !local

--- a/lib/discourse_activity_pub/ap/handlers.rb
+++ b/lib/discourse_activity_pub/ap/handlers.rb
@@ -28,7 +28,7 @@ module DiscourseActivityPub
         end
   
         def handler_types
-          %w(validate perform store respond_to forward)
+          %w(validate perform resolve store respond_to forward)
         end
   
         def handler_keys(object_type, handler_type)

--- a/lib/discourse_activity_pub/json_ld.rb
+++ b/lib/discourse_activity_pub/json_ld.rb
@@ -101,6 +101,10 @@ module DiscourseActivityPub
       SecureRandom.hex(16)
     end
 
+    def generate_id(type)
+      json_ld_id(type, generate_key)
+    end
+
     def address_json(json, args = {})
       object_keys = %w(object)
       item_keys = %w(items orderedItems)
@@ -146,6 +150,7 @@ module DiscourseActivityPub
     module_function :publicly_addressed?
     module_function :addressed_to
     module_function :generate_key
+    module_function :generate_id
     module_function :domain_from_id
     module_function :address_json
     module_function :address_to_actor_id

--- a/spec/fabricators/discourse_activity_pub_actor_fabricator.rb
+++ b/spec/fabricators/discourse_activity_pub_actor_fabricator.rb
@@ -2,10 +2,11 @@
 
 Fabricator(:discourse_activity_pub_actor) do
   ap_type { "Actor" }
-  domain { "forum.com" }
+  domain { DiscourseActivityPub.host }
   username { sequence(:username) { |i| "username#{i}"} }
 
   before_create do
+    self.domain = "remote.com" unless local
     self.ap_id = "https://#{self.domain}/actor/#{SecureRandom.hex(16)}" unless self.ap_id || local
   end
 

--- a/spec/lib/discourse_activity_pub/activity_forwarder_spec.rb
+++ b/spec/lib/discourse_activity_pub/activity_forwarder_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe DiscourseActivityPub::ActivityForwarder do
           end
   
           context "when the first post note is remote" do
-            let!(:remote_topic_actor_ap_id) { "https://forum.com/actor/12345" }
+            let!(:remote_topic_actor_ap_id) { DiscourseActivityPub::JsonLd.generate_id('Actor') }
             let!(:remote_topic_actor) { Fabricate(:discourse_activity_pub_actor, ap_id: remote_topic_actor_ap_id, local: false) }
   
             before do

--- a/spec/lib/discourse_activity_pub/ap/activity_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity_spec.rb
@@ -146,6 +146,21 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
             expect(@fake_logger.warnings.any?).to eq(false)
           end
         end
+
+        context "with a local object uri" do
+          let!(:json) {
+            build_activity_json(
+              object: note.ap.json['id'],
+              type: activity_type,
+              actor: person
+            )
+          }
+
+          it "resolves the local object without a request" do
+            expect_no_request
+            expect(perform_process(json, activity_type)).to eq(true)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Context: https://socialhub.activitypub.rocks/t/adding-federation-support-to-discourse/2966/31

@pmusaraj The issue reported in the linked topic arises when the external actor uses an id in the `object` instead of the full object. While addressing that I took this opportunity to properly disambiguate object resolution (`resolve`) and object storage (`store`) in the processing (incoming) pipeline.