### PR TITLE
FIX: ensure process transaction errors are logged

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -85,20 +85,18 @@ en:
         announce_not_publicly_addressed: "Announcement is not publicly addressed."
         only_category_actors_accept_new_topics: "Only category actors accept new topics."
         only_followed_actors_create_new_topics: "Only followed actors can create new topics."
-        failed_to_respond_to_follow: "Failed to respond to follow: %{follow}"
-        failed_to_save_activity: "Failed to save activity: %{activity}"
-        failed_to_save_object: "Failed to save object: %{object}"
-        failed_to_save_actor: "Failed to save actor: %{actor}"
-        failed_to_save_collection: "Failed to save collection: %{collection}"
+        actor_already_following: "Actor is already following that object"
+      error:
+        failed_to_create_user: "Failed to create user for %{actor_id}"
+        failed_to_create_post: "Failed to create post for %{object_id}"
+        failed_to_respond_to_follow: "Failed to respond to follow: %{activity_id}"
+        failed_to_save_activity: "Failed to save activity: %{activity_id}"
+        failed_to_save_object: "Failed to save object: %{object_id}"
+        failed_to_save_actor: "Failed to save actor: %{actor_id}"
+        failed_to_save_collection: "Failed to save collection: %{collection_id}"
       info:
         received_json: "Received JSON delivered to %{delivered_to}"
         processing_json: "Processing JSON delivered to %{delivered_to}"
-    activity:
-      create:
-        failed_to_create_user: "Failed to create user for %{actor_id}"
-        failed_to_create_post: "%{user_id} failed to create post for %{object_id}"
-      reject:
-        actor_already_following: "Actor is already following that object"
     webfinger:
       error:
         not_enabled: "Webfinger is not enabled"

--- a/lib/discourse_activity_pub/ap/activity.rb
+++ b/lib/discourse_activity_pub/ap/activity.rb
@@ -34,7 +34,8 @@ module DiscourseActivityPub
             perform_activity
             store_activity
             respond_to_activity
-          rescue DiscourseActivityPub::AP::Handlers::Error
+          rescue DiscourseActivityPub::AP::Handlers::Error => error
+            DiscourseActivityPub::Logger.error(error.message)
             raise ActiveRecord::Rollback
           end
         end

--- a/lib/discourse_activity_pub/ap/activity/response.rb
+++ b/lib/discourse_activity_pub/ap/activity/response.rb
@@ -35,7 +35,7 @@ module DiscourseActivityPub
         protected
 
         def reject_message_from_key(key)
-          I18n.t("discourse_activity_pub.activity.reject.#{key}")
+          I18n.t("discourse_activity_pub.process.warning.#{key}")
         end
       end
     end

--- a/lib/discourse_activity_pub/ap/handlers.rb
+++ b/lib/discourse_activity_pub/ap/handlers.rb
@@ -24,7 +24,7 @@ module DiscourseActivityPub
           object_type,
           handler_type,
           parent: parent,
-          raise_errors: false,
+          raise_errors: raise_errors,
         )
       end
 
@@ -51,13 +51,10 @@ module DiscourseActivityPub
           type, handler = handler_keys(object_type, handler_type)
           return [] unless type && handler
           klass = get_klass(object_type.to_s)
+          _handlers = [*sorted_handlers.dig(*[type, handler])]
           base_type = klass.base_type.downcase.to_sym
-          [
-            *(
-              [*sorted_handlers.dig(*[type, handler])] +
-                [*sorted_handlers.dig(*[base_type, handler])]
-            ),
-          ].map { |h| h[:proc] }.compact
+          _handlers += [*sorted_handlers.dig(*[base_type, handler])] if type != base_type
+          _handlers.map { |h| h[:proc] }.compact
         end
 
         def add_handler(object_type, handler_type, priority = 0, &block)

--- a/lib/discourse_activity_pub/post_handler.rb
+++ b/lib/discourse_activity_pub/post_handler.rb
@@ -95,8 +95,8 @@ module DiscourseActivityPub
         else
           raise DiscourseActivityPub::AP::Handlers::Error::Store,
                 I18n.t(
-                  "discourse_activity_pub.process.warning.failed_to_save_collection",
-                  collection: DiscourseActivityPub::JsonLd.resolve_id(raw_collection),
+                  "discourse_activity_pub.process.error.failed_to_save_collection",
+                  collection_id: DiscourseActivityPub::JsonLd.resolve_id(raw_collection),
                 )
         end
       else

--- a/plugin.rb
+++ b/plugin.rb
@@ -820,8 +820,8 @@ after_initialize do
     unless user
       raise DiscourseActivityPub::AP::Handlers::Error::Perform,
             I18n.t(
-              "discourse_activity_pub.activity.create.failed_to_create_user",
-              actor_id: activity.object.stored.attributed_to&.id,
+              "discourse_activity_pub.process.error.failed_to_create_user",
+              actor_id: activity.object.stored.attributed_to&.ap_id,
             )
     end
 
@@ -835,8 +835,7 @@ after_initialize do
     unless post
       raise DiscourseActivityPub::AP::Handlers::Error::Perform,
             I18n.t(
-              "discourse_activity_pub.activity.create.failed_to_create_post",
-              user_id: user.id,
+              "discourse_activity_pub.process.error.failed_to_create_post",
               object_id: activity.object.id,
             )
     end
@@ -860,7 +859,7 @@ after_initialize do
     unless user
       raise DiscourseActivityPub::AP::Handlers::Error::Perform,
             I18n.t(
-              "discourse_activity_pub.create.failed_to_create_user",
+              "discourse_activity_pub.process.error.failed_to_create_user",
               actor_id: activity.actor.id,
             )
     end
@@ -922,8 +921,8 @@ after_initialize do
       DiscourseActivityPub::Logger.object_store_error(response, error)
       raise DiscourseActivityPub::AP::Handlers::Error::RespondTo,
             I18n.t(
-              "discourse_activity_pub.process.warning.failed_to_respond_to_follow",
-              follow: activity.json[:id],
+              "discourse_activity_pub.process.error.failed_to_respond_to_follow",
+              activity_id: activity.json[:id],
             )
     end
 
@@ -967,8 +966,8 @@ after_initialize do
       DiscourseActivityPub::Logger.object_store_error(activity, error)
       raise DiscourseActivityPub::AP::Handlers::Error::Store,
             I18n.t(
-              "discourse_activity_pub.process.warning.failed_to_save_activity",
-              activity: activity.json[:id],
+              "discourse_activity_pub.process.error.failed_to_save_activity",
+              activity_id: activity.json[:id],
             )
     end
 
@@ -1031,8 +1030,8 @@ after_initialize do
             DiscourseActivityPub::Logger.object_store_error(object, error)
             raise DiscourseActivityPub::AP::Handlers::Error::Store,
                   I18n.t(
-                    "discourse_activity_pub.process.warning.failed_to_save_object",
-                    object: object.json[:id],
+                    "discourse_activity_pub.process.error.failed_to_save_object",
+                    object_id: object.json[:id],
                   )
           end
         end
@@ -1076,8 +1075,8 @@ after_initialize do
           DiscourseActivityPub::Logger.object_store_error(actor, error)
           raise DiscourseActivityPub::AP::Handlers::Error::Store,
                 I18n.t(
-                  "discourse_activity_pub.process.warning.failed_to_save_actor",
-                  actor: actor.json[:id],
+                  "discourse_activity_pub.process.error.failed_to_save_actor",
+                  actor_id: actor.json[:id],
                 )
         end
       end
@@ -1104,17 +1103,11 @@ after_initialize do
         }
         collection.stored = DiscourseActivityPubCollection.new(params)
       end
-
       if collection.stored.new_record? || collection.stored.changed?
         begin
           collection.stored.save!
         rescue ActiveRecord::RecordInvalid => error
           DiscourseActivityPub::Logger.object_store_error(collection, error)
-          raise DiscourseActivityPub::AP::Handlers::Error::Store,
-                I18n.t(
-                  "discourse_activity_pub.process.warning.failed_to_save_collection",
-                  collection: collection.json[:id],
-                )
         end
       end
     end

--- a/spec/lib/discourse_activity_pub/ap/activity/create_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/create_spec.rb
@@ -86,9 +86,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
         perform_process(reply_json)
       end
 
-      after do
-        teardown_logging
-      end
+      after { teardown_logging }
 
       it "does not create a post" do
         expect(Post.exists?(raw: reply_json[:object][:content])).to be(false)
@@ -181,17 +179,15 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
             DiscourseActivityPub::UserHandler.stubs(:update_or_create_user).returns(nil)
             perform_process(new_post_json, delivered_to)
           end
-  
-          after do
-            teardown_logging
-          end
-  
+
+          after { teardown_logging }
+
           it "logs the right error" do
             expect(@fake_logger.errors.last).to match(
               I18n.t(
                 "discourse_activity_pub.process.error.failed_to_create_user",
                 actor_id: person.ap_id,
-              )
+              ),
             )
           end
         end
@@ -203,16 +199,14 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
             perform_process(new_post_json, delivered_to)
           end
 
-          after do
-            teardown_logging
-          end
+          after { teardown_logging }
 
           it "logs the right error" do
             expect(@fake_logger.errors.last).to match(
               I18n.t(
                 "discourse_activity_pub.process.error.failed_to_create_post",
                 object_id: object_json[:id],
-              )
+              ),
             )
           end
         end
@@ -250,9 +244,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
           perform_process(new_post_json, delivered_to)
         end
 
-        after do
-          teardown_logging
-        end
+        after { teardown_logging }
 
         it "does not create a post" do
           expect(Post.exists?(raw: new_post_json[:object][:content])).to be(false)

--- a/spec/lib/discourse_activity_pub/ap/activity/follow_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/follow_spec.rb
@@ -115,24 +115,21 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Follow do
 
             before do
               setup_logging
-              DiscourseActivityPubFollow.expects(:create!).raises(
-                ActiveRecord::RecordInvalid.new(
-                  DiscourseActivityPubFollow.new
-                )
-              ).once
+              DiscourseActivityPubFollow
+                .expects(:create!)
+                .raises(ActiveRecord::RecordInvalid.new(DiscourseActivityPubFollow.new))
+                .once
               perform_process(json)
             end
 
-            after do
-              teardown_logging
-            end
+            after { teardown_logging }
 
             it "logs the right error" do
               expect(@fake_logger.errors.last).to match(
                 I18n.t(
                   "discourse_activity_pub.process.error.failed_to_respond_to_follow",
                   activity_id: json[:id],
-                )
+                ),
               )
             end
           end

--- a/spec/lib/discourse_activity_pub/ap/activity/follow_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/follow_spec.rb
@@ -109,6 +109,33 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Follow do
 
             include_examples "processes a new follow"
           end
+
+          context "when follow creation fails" do
+            let!(:json) { build_activity_json(object: category.activity_pub_actor.ap_id) }
+
+            before do
+              setup_logging
+              DiscourseActivityPubFollow.expects(:create!).raises(
+                ActiveRecord::RecordInvalid.new(
+                  DiscourseActivityPubFollow.new
+                )
+              ).once
+              perform_process(json)
+            end
+
+            after do
+              teardown_logging
+            end
+
+            it "logs the right error" do
+              expect(@fake_logger.errors.last).to match(
+                I18n.t(
+                  "discourse_activity_pub.process.error.failed_to_respond_to_follow",
+                  activity_id: json[:id],
+                )
+              )
+            end
+          end
         end
 
         context "when already following" do

--- a/spec/lib/discourse_activity_pub/ap/activity_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity_spec.rb
@@ -35,20 +35,43 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
       end
 
       context "with verbose logging enabled" do
-        before { SiteSetting.activity_pub_verbose_logging = true }
-
-        before do
-          @orig_logger = Rails.logger
-          Rails.logger = @fake_logger = FakeLogger.new
-        end
-
-        after { Rails.logger = @orig_logger }
+        before { setup_logging }
+        after { teardown_logging }
 
         it "logs the right warning" do
           perform_process(json, activity_type)
           perform_process(json, activity_type)
           expect(@fake_logger.warnings.first).to eq(
             build_process_warning("activity_already_processed", json["id"]),
+          )
+        end
+      end
+    end
+
+    context "when fails to create activity" do
+      before do
+        DiscourseActivityPubActivity.expects(:create!).raises(
+          ActiveRecord::RecordInvalid.new(
+            DiscourseActivityPubActivity.new
+          )
+        ).once
+      end
+
+      it "returns true" do
+        expect(perform_process(json, activity_type)).to eq(true)
+      end
+
+      context "with verbose logging enabled" do
+        before { setup_logging }
+        after { teardown_logging }
+
+        it "logs the right error" do
+          perform_process(json, activity_type)
+          expect(@fake_logger.errors.last).to match(
+            I18n.t(
+              "discourse_activity_pub.process.error.failed_to_save_activity",
+              activity_id: json[:id]
+            )
           )
         end
       end
@@ -84,14 +107,8 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
         end
 
         context "with verbose logging enabled" do
-          before { SiteSetting.activity_pub_verbose_logging = true }
-
-          before do
-            @orig_logger = Rails.logger
-            Rails.logger = @fake_logger = FakeLogger.new
-          end
-
-          after { Rails.logger = @orig_logger }
+          before { setup_logging }
+          after { teardown_logging }
 
           it "logs a warning" do
             perform_process(json, activity_type)
@@ -122,14 +139,8 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
         end
 
         context "with verbose logging enabled" do
-          before { SiteSetting.activity_pub_verbose_logging = true }
-
-          before do
-            @orig_logger = Rails.logger
-            Rails.logger = @fake_logger = FakeLogger.new
-          end
-
-          after { Rails.logger = @orig_logger }
+          before { setup_logging }
+          after { teardown_logging }
 
           it "does not log a warning" do
             perform_process(json, activity_type)
@@ -167,14 +178,8 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
         end
 
         context "with verbose logging enabled" do
-          before { SiteSetting.activity_pub_verbose_logging = true }
-
-          before do
-            @orig_logger = Rails.logger
-            Rails.logger = @fake_logger = FakeLogger.new
-          end
-
-          after { Rails.logger = @orig_logger }
+          before { setup_logging }
+          after { teardown_logging }
 
           it "logs a warning" do
             perform_process(@json, activity_type)
@@ -198,14 +203,8 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
         end
 
         context "with verbose logging enabled" do
-          before { SiteSetting.activity_pub_verbose_logging = true }
-
-          before do
-            @orig_logger = Rails.logger
-            Rails.logger = @fake_logger = FakeLogger.new
-          end
-
-          after { Rails.logger = @orig_logger }
+          before { setup_logging }
+          after { teardown_logging }
 
           it "logs a warning" do
             perform_process(@json, activity_type)

--- a/spec/lib/discourse_activity_pub/ap/activity_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity_spec.rb
@@ -50,11 +50,10 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
 
     context "when fails to create activity" do
       before do
-        DiscourseActivityPubActivity.expects(:create!).raises(
-          ActiveRecord::RecordInvalid.new(
-            DiscourseActivityPubActivity.new
-          )
-        ).once
+        DiscourseActivityPubActivity
+          .expects(:create!)
+          .raises(ActiveRecord::RecordInvalid.new(DiscourseActivityPubActivity.new))
+          .once
       end
 
       it "returns true" do
@@ -70,8 +69,8 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
           expect(@fake_logger.errors.last).to match(
             I18n.t(
               "discourse_activity_pub.process.error.failed_to_save_activity",
-              activity_id: json[:id]
-            )
+              activity_id: json[:id],
+            ),
           )
         end
       end

--- a/spec/lib/discourse_activity_pub/ap/collection_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/collection_spec.rb
@@ -88,10 +88,12 @@ RSpec.describe DiscourseActivityPub::AP::Collection do
 
       before do
         collection_stub = DiscourseActivityPubCollection.new
-        collection_stub.errors.add(:base, ar_error)     
-        DiscourseActivityPubCollection.any_instance.expects(:save!).raises(
-          ActiveRecord::RecordInvalid.new(collection_stub)
-        ).once
+        collection_stub.errors.add(:base, ar_error)
+        DiscourseActivityPubCollection
+          .any_instance
+          .expects(:save!)
+          .raises(ActiveRecord::RecordInvalid.new(collection_stub))
+          .once
       end
 
       context "with verbose logging enabled" do

--- a/spec/lib/discourse_activity_pub/ap/collection_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/collection_spec.rb
@@ -74,4 +74,35 @@ RSpec.describe DiscourseActivityPub::AP::Collection do
       perform_process(collection_json)
     end
   end
+
+  describe "#resolve_and_store" do
+    let!(:collection_json) { build_collection_json(type: "OrderedCollection") }
+
+    it "stores the collection" do
+      described_class.resolve_and_store(collection_json)
+      expect(DiscourseActivityPubCollection.exists?(ap_id: collection_json[:id])).to eq(true)
+    end
+
+    context "when store fails" do
+      let!(:ar_error) { "Failed to save collection" }
+
+      before do
+        collection_stub = DiscourseActivityPubCollection.new
+        collection_stub.errors.add(:base, ar_error)     
+        DiscourseActivityPubCollection.any_instance.expects(:save!).raises(
+          ActiveRecord::RecordInvalid.new(collection_stub)
+        ).once
+      end
+
+      context "with verbose logging enabled" do
+        before { setup_logging }
+        after { teardown_logging }
+
+        it "logs the right error" do
+          described_class.resolve_and_store(collection_json)
+          expect(@fake_logger.errors.first).to match(ar_error)
+        end
+      end
+    end
+  end
 end

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -186,11 +186,11 @@ def build_activity_json(
   _json.with_indifferent_access
 end
 
-def build_collection_json(items: [], to: nil, cc: nil, audience: nil)
+def build_collection_json(type: "Collection", items: [], to: nil, cc: nil, audience: nil)
   _json = {
     "@context": "https://www.w3.org/ns/activitystreams",
     id: "https://external.com/collection/#{SecureRandom.hex(8)}",
-    type: "Collection",
+    type: type,
     items: items,
   }
   _json[:to] = to if to
@@ -269,4 +269,15 @@ def expect_post(returns: true)
     DiscourseActivityPub::DeliveryFailureTracker.any_instance.expects(:track_failure).once
     DiscourseActivityPubActivity.any_instance.expects(:after_deliver).with(false).once
   end
+end
+
+def setup_logging
+  SiteSetting.activity_pub_verbose_logging = true
+  @orig_logger = Rails.logger
+  Rails.logger = @fake_logger = FakeLogger.new
+end
+
+def teardown_logging
+  Rails.logger = @orig_logger
+  SiteSetting.activity_pub_verbose_logging = false
 end


### PR DESCRIPTION
Errors raised during the transaction handlers in the process pipeline were not being logged properly.