### PR TITLE
Add outbox import

### DIFF
--- a/app/models/discourse_activity_pub_actor.rb
+++ b/app/models/discourse_activity_pub_actor.rb
@@ -194,6 +194,16 @@ class DiscourseActivityPubActor < ActiveRecord::Base
     actor
   end
 
+  def self.find_by_id_or_handle(id_or_handle, local: true, refresh: false)
+    if id_or_handle.include?("@")
+      find_by_handle(id_or_handle, local: local, refresh: refresh)
+    elsif DiscourseActivityPub::URI.valid_url?(id_or_handle)
+      find_by_ap_id(id_or_handle, local: local, refresh: refresh)
+    else
+      find_by(id: id_or_handle)
+    end
+  end
+
   def self.resolve_and_store_by_handle(raw_handle)
     ap_id = DiscourseActivityPub::Webfinger.resolve_id_by_handle(raw_handle)
     return nil unless ap_id

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -149,6 +149,10 @@ en:
       info:
         successfully_delivered: "%{from_actor} successfully delivered to %{send_to}"
     import:
+      warning:
+        import_did_not_start: "%{actor_id} failed to import the outbox of %{target_actor_id}"
+        actors_not_ready: "Actors are not ready"
+        not_following_target: "%{actor_id} is not following %{target_actor_id}"
       info:
         import_started: "%{actor_id} started to import activities from %{target_actor_id}"
   site_settings:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -148,6 +148,9 @@ en:
         failed_to_deliver: "%{from_actor} failed to deliver to %{send_to}"
       info:
         successfully_delivered: "%{from_actor} successfully delivered to %{send_to}"
+    import:
+      info:
+        import_started: "%{actor_id} started to import activities from %{target_actor_id}"
   site_settings:
     activity_pub_enabled: "Enable ActivityPub plugin."
     activity_pub_rate_limit_post_to_inbox_per_minute: "Number of POST requests that can be made to an actor's inbox per minute."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -86,6 +86,7 @@ en:
         only_category_actors_accept_new_topics: "Only category actors accept new topics."
         only_followed_actors_create_new_topics: "Only followed actors can create new topics."
         actor_already_following: "Actor is already following that object"
+        invalid_collection_item: "Invalid item"
       error:
         failed_to_create_user: "Failed to create user for %{actor_id}"
         failed_to_create_post: "Failed to create post for %{object_id}"
@@ -150,11 +151,13 @@ en:
         successfully_delivered: "%{from_actor} successfully delivered to %{send_to}"
     import:
       warning:
-        import_did_not_start: "%{actor_id} failed to import the outbox of %{target_actor_id}"
+        import_did_not_start: "%{actor} failed to import the outbox of %{target_actor}"
         actors_not_ready: "Actors are not ready"
-        not_following_target: "%{actor_id} is not following %{target_actor_id}"
+        not_following_target: "%{actor} is not following %{target_actor}"
+        outbox_response_invalid: "outbox of %{target_actor} returned an invalid response"
       info:
-        import_started: "%{actor_id} started to import activities from %{target_actor_id}"
+        import_started: "%{actor} started to import %{activity_count} activities from %{target_actor}"
+        import_finished: "%{actor} imported %{success_count} new activities from %{target_actor}"
   site_settings:
     activity_pub_enabled: "Enable ActivityPub plugin."
     activity_pub_rate_limit_post_to_inbox_per_minute: "Number of POST requests that can be made to an actor's inbox per minute."

--- a/lib/discourse_activity_pub/ap/activity.rb
+++ b/lib/discourse_activity_pub/ap/activity.rb
@@ -23,12 +23,16 @@ module DiscourseActivityPub
       def process
         return false unless process_actor_and_object
         return false unless perform_validate_activity
+        return false unless perform_transactions
 
-        perform_transactions
         forward_activity
+
+        self
       end
 
       def perform_transactions
+        performed = true
+
         ActiveRecord::Base.transaction do
           begin
             perform_activity
@@ -36,9 +40,12 @@ module DiscourseActivityPub
             respond_to_activity
           rescue DiscourseActivityPub::AP::Handlers::Error => error
             DiscourseActivityPub::Logger.error(error.message)
+            performed = false
             raise ActiveRecord::Rollback
           end
         end
+
+        performed
       end
 
       def perform_validate_activity

--- a/lib/discourse_activity_pub/ap/collection/ordered_collection.rb
+++ b/lib/discourse_activity_pub/ap/collection/ordered_collection.rb
@@ -16,7 +16,16 @@ module DiscourseActivityPub
         end
 
         def process_items
-          json["orderedItems"]
+          @process_items ||=
+            begin
+              return json["orderedItems"] if json["orderedItems"]
+
+              if json["first"].present?
+                page_href = json["first"].is_a?(String) ? json["first"] : json.dig("first", "href")
+                page = request_object(page_href)
+                page["orderedItems"]
+              end
+            end
         end
       end
     end

--- a/lib/discourse_activity_pub/engine.rb
+++ b/lib/discourse_activity_pub/engine.rb
@@ -39,4 +39,25 @@ module DiscourseActivityPub
   def self.icon_url
     SiteIconManager.large_icon_url
   end
+
+  def self.info(ap_id)
+    result = DB.query(<<~SQL, ap_id: ap_id)
+      SELECT id, 'Activity' as type, ap_type, COALESCE(local, FALSE) as local
+      FROM discourse_activity_pub_activities
+      WHERE ap_id = :ap_id
+      UNION
+      SELECT id, 'Actor' as type, ap_type, COALESCE(local, FALSE) as local
+      FROM discourse_activity_pub_actors
+      WHERE ap_id = :ap_id
+      UNION
+      SELECT id, 'Collection' as type, ap_type, COALESCE(local, FALSE) as local
+      FROM discourse_activity_pub_collections
+      WHERE ap_id = :ap_id
+      UNION
+      SELECT id, 'Object' as type, ap_type, COALESCE(local, FALSE) as local
+      FROM discourse_activity_pub_objects
+      WHERE ap_id = :ap_id
+    SQL
+    result.present? ? result.first : nil
+  end
 end

--- a/lib/discourse_activity_pub/engine.rb
+++ b/lib/discourse_activity_pub/engine.rb
@@ -40,24 +40,37 @@ module DiscourseActivityPub
     SiteIconManager.large_icon_url
   end
 
-  def self.info(ap_id)
-    result = DB.query(<<~SQL, ap_id: ap_id)
-      SELECT id, 'Activity' as type, ap_type, COALESCE(local, FALSE) as local
+  def self.info(ap_ids)
+    return nil unless ap_ids
+
+    results = DB.query(<<~SQL, ap_ids: ap_ids)
+      SELECT id, 'Activity' as type, ap_type, COALESCE(local, FALSE) as local, replace(object_type, 'DiscourseActivityPub', '') as object_type, object_id, NULL as model_type, NULL as model_id
       FROM discourse_activity_pub_activities
-      WHERE ap_id = :ap_id
+      WHERE ap_id = ANY (ARRAY[:ap_ids])
       UNION
-      SELECT id, 'Actor' as type, ap_type, COALESCE(local, FALSE) as local
+      SELECT id, 'Actor' as type, ap_type, COALESCE(local, FALSE) as local, NULL as object_type, NULL as object_id, model_type, model_id
       FROM discourse_activity_pub_actors
-      WHERE ap_id = :ap_id
+      WHERE ap_id = ANY (ARRAY[:ap_ids])
       UNION
-      SELECT id, 'Collection' as type, ap_type, COALESCE(local, FALSE) as local
+      SELECT id, 'Collection' as type, ap_type, COALESCE(local, FALSE) as local, NULL as object_type, NULL as object_id, model_type, model_id
       FROM discourse_activity_pub_collections
-      WHERE ap_id = :ap_id
+      WHERE ap_id = ANY (ARRAY[:ap_ids])
       UNION
-      SELECT id, 'Object' as type, ap_type, COALESCE(local, FALSE) as local
+      SELECT id, 'Object' as type, ap_type, COALESCE(local, FALSE) as local, NULL as object_type, NULL as object_id, model_type, model_id
       FROM discourse_activity_pub_objects
-      WHERE ap_id = :ap_id
+      WHERE ap_id = ANY (ARRAY[:ap_ids])
     SQL
-    result.present? ? result.first : nil
+
+    return nil unless results.present?
+
+    results.each do |result|
+      if result.type == "Activity" && result.object_type == "Object"
+        object = DiscourseActivityPubObject.find_by(id: result.object_id)
+        result.model_type = object.model_type
+        result.model_id = object.model_id
+      end
+    end
+
+    results
   end
 end

--- a/lib/discourse_activity_pub/logger.rb
+++ b/lib/discourse_activity_pub/logger.rb
@@ -19,7 +19,7 @@ module DiscourseActivityPub
 
       Rails.logger.send(type, formatted_message(message, **rails_args))
       AP.logger.send(type, formatted_message(message, json: json)) if Rails.env.development?
-      puts formatted_message(message) if log_type?(to_stdout)
+      puts formatted_message(message) if print_to_stdout?
       true
     end
 
@@ -32,9 +32,17 @@ module DiscourseActivityPub
       result
     end
 
-    def log_type?(type_setting)
-      return false unless type_setting
-      self.class.log_types.index(type) >= self.class.log_types.index(type_setting)
+    def print_to_stdout?
+      case to_stdout
+      when :error
+        type == :error
+      when :info
+        %i[error info].include?(type)
+      when :warn
+        %i[error info warn].include?(type)
+      else
+        false
+      end
     end
 
     def self.log_types

--- a/lib/discourse_activity_pub/logger.rb
+++ b/lib/discourse_activity_pub/logger.rb
@@ -16,10 +16,10 @@ module DiscourseActivityPub
       return unless SiteSetting.activity_pub_verbose_logging
       rails_args = {}
       rails_args[:json] = json if SiteSetting.activity_pub_object_logging && !Rails.env.development?
-      
+
       Rails.logger.send(type, formatted_message(message, **rails_args))
       AP.logger.send(type, formatted_message(message, json: json)) if Rails.env.development?
-      puts formatted_message(message) if to_stdout
+      puts formatted_message(message) if log_type?(to_stdout)
       true
     end
 
@@ -30,6 +30,15 @@ module DiscourseActivityPub
         result += "\n#{json.to_yaml}" if json.present?
       end
       result
+    end
+
+    def log_type?(type_setting)
+      return false unless type_setting
+      self.class.log_types.index(type) >= self.class.log_types.index(type_setting)
+    end
+
+    def self.log_types
+      %i[error warn info]
     end
 
     def self.error(message, json: nil)

--- a/lib/discourse_activity_pub/logger.rb
+++ b/lib/discourse_activity_pub/logger.rb
@@ -6,6 +6,7 @@ module DiscourseActivityPub
 
     PREFIX = "[Discourse Activity Pub]"
     attr_reader :type
+    cattr_accessor :to_stdout
 
     def initialize(type)
       @type = type
@@ -15,8 +16,10 @@ module DiscourseActivityPub
       return unless SiteSetting.activity_pub_verbose_logging
       rails_args = {}
       rails_args[:json] = json if SiteSetting.activity_pub_object_logging && !Rails.env.development?
+      
       Rails.logger.send(type, formatted_message(message, **rails_args))
       AP.logger.send(type, formatted_message(message, json: json)) if Rails.env.development?
+      puts formatted_message(message) if to_stdout
       true
     end
 

--- a/lib/discourse_activity_pub/outbox_importer.rb
+++ b/lib/discourse_activity_pub/outbox_importer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module DiscourseActivityPub
+  class OutboxImporter
+    attr_reader :actor
+    attr_reader :target_actor
+
+    def initialize(actor_id: nil, target_actor_id: nil)
+      @actor = DiscourseActivityPubActor.find_by(id: actor_id)
+      @target_actor = DiscourseActivityPubActor.find_by(id: target_actor_id)
+    end
+
+    def perform
+      return nil unless actor&.ready? && target_actor&.ready?
+
+      response = DiscourseActivityPub::Request.get_json_ld(
+        uri: target_actor.outbox
+      )
+      return nil unless response
+
+      collection = DiscourseActivityPub::AP::Object.factory(response)
+      return unless collection&.type == DiscourseActivityPub::AP::Collection::OrderedCollection.type
+
+      log_import_start
+      collection.delivered_to << actor.ap_id
+      collection.process
+    end
+
+    def self.perform(actor_id: nil, target_actor_id: nil)
+      new(actor_id: actor_id, target_actor_id: target_actor_id).perform
+    end
+
+    protected
+
+    def log_import_start
+      DiscourseActivityPub::Logger.info(
+        I18n.t(
+          "discourse_activity_pub.import.info.import_started",
+          actor_id: actor.ap_id,
+          target_actor_id: target_actor.ap_id
+        ),
+      )
+    end
+  end
+end

--- a/lib/tasks/activity_pub.rake
+++ b/lib/tasks/activity_pub.rake
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+desc "Print information about a stored ActivityPub object"
+task "activity_pub:info", %i[ap_id] => :environment do |_, args|
+  ap_id = args[:ap_id]
+
+  if !ap_id || !DiscourseActivityPub::URI.parse(ap_id)
+    puts "ERROR: Expecting activity_pub:import_outbox[ap_id]"
+    exit 1
+  end
+
+  object = DiscourseActivityPub.info(ap_id)
+
+  if !object
+    puts "Could not find #{ap_id}"
+    exit 1
+  end
+
+  columns = "%-5s | %-10s | %-10s | %-10s\n"
+  line = "--------------------------------------------\n"
+  puts "\n"
+  puts "ActivityPub info for #{ap_id}"
+  puts line
+  printf columns,
+         "id",
+         "type",
+         "ap_type",
+         "local"
+  puts line
+  printf columns,
+         object.id,
+         object.type,
+         object.ap_type,
+         object.local
+  puts line
+  puts "\n"
+end
+
+desc "Imports activities from an actor's outbox"
+task "activity_pub:import_outbox", %i[actor_id target_actor_id] => :environment do |_, args|
+  actor_id = args[:actor_id]
+  target_actor_id = args[:target_actor_id]
+
+  if !actor_id || !target_actor_id
+    puts "ERROR: Expecting activity_pub:import_outbox[actor_id,target_actor_id]"
+    exit 1
+  end
+
+  DiscourseActivityPub::Logger.to_stdout = true
+  DiscourseActivityPub::OutboxImporter.perform(actor_id: actor_id, target_actor_id: target_actor_id)
+end

--- a/lib/tasks/activity_pub.rake
+++ b/lib/tasks/activity_pub.rake
@@ -4,30 +4,23 @@ def print_info(info)
   return unless info
 
   columns = "%-5s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s\n"
-  line = "------------------------------------------------------------------------------------------------\n"
+  line =
+    "------------------------------------------------------------------------------------------------\n"
   puts "\n"
   puts "ActivityPub Info"
   puts line
-  printf columns,
-         "id",
-         "type",
-         "subtype",
-         "local",
-         "object",
-         "object id",
-         "model",
-         "model id"
+  printf columns, "id", "type", "subtype", "local", "object", "object id", "model", "model id"
   info.each do |object|
     puts line
     printf columns,
-          object.id,
-          object.type,
-          object.ap_type,
-          object.local,
-          object.object_type,
-          object.object_id,
-          object.model_type,
-          object.model_id
+           object.id,
+           object.type,
+           object.ap_type,
+           object.local,
+           object.object_type,
+           object.object_id,
+           object.model_type,
+           object.model_id
   end
   puts line
   puts "\n"
@@ -53,7 +46,8 @@ task "activity_pub:info", %i[ap_ids] => :environment do |_, args|
 end
 
 desc "Imports activities from an actor's outbox"
-task "activity_pub:import_outbox", %i[actor_id_or_handle target_actor_id_or_handle log_type] => :environment do |_, args|
+task "activity_pub:import_outbox",
+     %i[actor_id_or_handle target_actor_id_or_handle log_type] => :environment do |_, args|
   actor_id_or_handle = args[:actor_id_or_handle]
   target_actor_id_or_handle = args[:target_actor_id_or_handle]
   log_type = args[:log_type]
@@ -70,7 +64,8 @@ task "activity_pub:import_outbox", %i[actor_id_or_handle target_actor_id_or_hand
     exit 1
   end
 
-  target_actor = DiscourseActivityPubActor.find_by_id_or_handle(target_actor_id_or_handle, local: false)
+  target_actor =
+    DiscourseActivityPubActor.find_by_id_or_handle(target_actor_id_or_handle, local: false)
 
   if !target_actor
     puts "Could not find target actor"
@@ -85,7 +80,11 @@ task "activity_pub:import_outbox", %i[actor_id_or_handle target_actor_id_or_hand
   end
 
   DiscourseActivityPub::Logger.to_stdout = log_type
-  result = DiscourseActivityPub::OutboxImporter.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+  result =
+    DiscourseActivityPub::OutboxImporter.perform(
+      actor_id: actor.id,
+      target_actor_id: target_actor.id,
+    )
 
   if result[:success].present?
     info = DiscourseActivityPub.info(result[:success])

--- a/lib/tasks/activity_pub.rake
+++ b/lib/tasks/activity_pub.rake
@@ -1,51 +1,94 @@
 # frozen_string_literal: true
 
-desc "Print information about a stored ActivityPub object"
-task "activity_pub:info", %i[ap_id] => :environment do |_, args|
-  ap_id = args[:ap_id]
+def print_info(info)
+  return unless info
 
-  if !ap_id || !DiscourseActivityPub::URI.parse(ap_id)
-    puts "ERROR: Expecting activity_pub:import_outbox[ap_id]"
-    exit 1
-  end
-
-  object = DiscourseActivityPub.info(ap_id)
-
-  if !object
-    puts "Could not find #{ap_id}"
-    exit 1
-  end
-
-  columns = "%-5s | %-10s | %-10s | %-10s\n"
-  line = "--------------------------------------------\n"
+  columns = "%-5s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s\n"
+  line = "------------------------------------------------------------------------------------------------\n"
   puts "\n"
-  puts "ActivityPub info for #{ap_id}"
+  puts "ActivityPub Info"
   puts line
   printf columns,
          "id",
          "type",
-         "ap_type",
-         "local"
-  puts line
-  printf columns,
-         object.id,
-         object.type,
-         object.ap_type,
-         object.local
+         "subtype",
+         "local",
+         "object",
+         "object id",
+         "model",
+         "model id"
+  info.each do |object|
+    puts line
+    printf columns,
+          object.id,
+          object.type,
+          object.ap_type,
+          object.local,
+          object.object_type,
+          object.object_id,
+          object.model_type,
+          object.model_id
+  end
   puts line
   puts "\n"
 end
 
-desc "Imports activities from an actor's outbox"
-task "activity_pub:import_outbox", %i[actor_id target_actor_id] => :environment do |_, args|
-  actor_id = args[:actor_id]
-  target_actor_id = args[:target_actor_id]
+desc "Print information about a stored ActivityPub object"
+task "activity_pub:info", %i[ap_ids] => :environment do |_, args|
+  ap_ids = args[:ap_ids]
 
-  if !actor_id || !target_actor_id
-    puts "ERROR: Expecting activity_pub:import_outbox[actor_id,target_actor_id]"
+  if !ap_ids
+    puts "ERROR: Expecting activity_pub:info[ap_id|ap_id]"
     exit 1
   end
 
-  DiscourseActivityPub::Logger.to_stdout = true
-  DiscourseActivityPub::OutboxImporter.perform(actor_id: actor_id, target_actor_id: target_actor_id)
+  info = DiscourseActivityPub.info(ap_ids.split("|"))
+
+  if !info
+    puts "Could not find #{ap_ids}"
+    exit 1
+  end
+
+  print_info(info)
+end
+
+desc "Imports activities from an actor's outbox"
+task "activity_pub:import_outbox", %i[actor_id_or_handle target_actor_id_or_handle log_type] => :environment do |_, args|
+  actor_id_or_handle = args[:actor_id_or_handle]
+  target_actor_id_or_handle = args[:target_actor_id_or_handle]
+  log_type = args[:log_type]
+
+  if !actor_id_or_handle || !target_actor_id_or_handle
+    puts "ERROR: Expecting activity_pub:import_outbox[actor_id_or_handle,target_actor_id_or_handle,log_type]"
+    exit 1
+  end
+
+  actor = DiscourseActivityPubActor.find_by_id_or_handle(actor_id_or_handle)
+
+  if !actor
+    puts "Could not find actor"
+    exit 1
+  end
+
+  target_actor = DiscourseActivityPubActor.find_by_id_or_handle(target_actor_id_or_handle, local: false)
+
+  if !target_actor
+    puts "Could not find target actor"
+    exit 1
+  end
+
+  log_type = :info
+
+  if args[:log_type]
+    DiscourseActivityPub::Logger.log_types.include?(args[:log_type].to_sym)
+    log_type = args[:log_type].to_sym
+  end
+
+  DiscourseActivityPub::Logger.to_stdout = log_type
+  result = DiscourseActivityPub::OutboxImporter.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+
+  if result[:success].present?
+    info = DiscourseActivityPub.info(result[:success])
+    print_info(info)
+  end
 end

--- a/lib/tasks/activity_pub.rake
+++ b/lib/tasks/activity_pub.rake
@@ -54,22 +54,23 @@ task "activity_pub:info", %i[ap_id] => :environment do |_, args|
         object[:stored] = true
         object
       end
-  end
-  resolved_object = DiscourseActivityPub::AP::Object.resolve(ap_id)
+  else
+    resolved_object = DiscourseActivityPub::AP::Object.resolve(ap_id)
 
-  if resolved_object.present?
-    object = {
-      stored: false,
-      id: nil,
-      type: resolved_object.base_type,
-      ap_type: resolved_object.type,
-      local: false,
-      object_type: resolved_object.json.dig(:object, :type),
-      object_id: nil,
-      model_type: nil,
-      model_id: nil,
-    }
-    info = [object]
+    if resolved_object.present?
+      object = {
+        stored: false,
+        id: nil,
+        type: resolved_object.base_type,
+        ap_type: resolved_object.type,
+        local: false,
+        object_type: resolved_object.json.dig(:object, :type),
+        object_id: nil,
+        model_type: nil,
+        model_id: nil,
+      }
+      info = [object]
+    end
   end
 
   if !info.present?

--- a/plugin.rb
+++ b/plugin.rb
@@ -26,6 +26,7 @@ after_initialize do
     ../lib/discourse_activity_pub/post_handler.rb
     ../lib/discourse_activity_pub/delivery_handler.rb
     ../lib/discourse_activity_pub/follow_handler.rb
+    ../lib/discourse_activity_pub/outbox_importer.rb
     ../lib/discourse_activity_pub/auth.rb
     ../lib/discourse_activity_pub/auth/oauth.rb
     ../lib/discourse_activity_pub/auth/oauth/app.rb

--- a/spec/lib/discourse_activity_pub/ap/activity_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
 
     context "with a duplicate activity" do
       it "returns false" do
-        expect(perform_process(json, activity_type)).to eq(true)
+        perform_process(json, activity_type)
         expect(perform_process(json, activity_type)).to eq(false)
       end
 
@@ -56,8 +56,8 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
           .once
       end
 
-      it "returns true" do
-        expect(perform_process(json, activity_type)).to eq(true)
+      it "returns false" do
+        expect(perform_process(json, activity_type)).to eq(false)
       end
 
       context "with verbose logging enabled" do

--- a/spec/lib/discourse_activity_pub/outbox_importer_spec.rb
+++ b/spec/lib/discourse_activity_pub/outbox_importer_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe DiscourseActivityPub::OutboxImporter do
-  let!(:person1) { Fabricate(:discourse_activity_pub_actor_person, local: false) }
+  let!(:category) { Fabricate(:category) }
+  let!(:target_actor) { Fabricate(:discourse_activity_pub_actor_person, local: false) }
   let!(:person2_json) { build_actor_json }
-  let!(:object1_json) { build_object_json(name: "My cool title", attributed_to: person1) }
+  let!(:object1_json) { build_object_json(name: "My cool title", attributed_to: target_actor) }
   let!(:object2_json) { build_object_json(in_reply_to: object1_json[:id], attributed_to: person2_json[:id]) }
-  let!(:create_1_json) { build_activity_json(actor: person1, object: object1_json, type: "Create") }
+  let!(:create_1_json) { build_activity_json(actor: target_actor, object: object1_json, type: "Create") }
   let!(:create_2_json) { build_activity_json(actor: person2_json[:id], object: object2_json, type: "Create") }
   let!(:ordered_collection_json) do
     build_collection_json(
@@ -18,29 +19,114 @@ RSpec.describe DiscourseActivityPub::OutboxImporter do
   end
 
   describe "#perform" do
+    let!(:actor) { Fabricate(:discourse_activity_pub_actor_group, model: category) }
 
-    context "with a category actor following a remote actor" do
-      let!(:category) { Fabricate(:category) }
-      let!(:category_actor) { Fabricate(:discourse_activity_pub_actor_group, model: category) }
-      let!(:follow1) do
-        Fabricate(:discourse_activity_pub_follow, follower: category_actor, followed: person1)
+    def build_warning_log(key)
+      message = I18n.t(
+        "discourse_activity_pub.import.warning.import_did_not_start",
+        actor_id: actor.ap_id,
+        target_actor_id: target_actor.ap_id
+      )
+      message += ": " + I18n.t(
+        "discourse_activity_pub.import.warning.#{key}",
+        actor_id: actor.ap_id,
+        target_actor_id: target_actor.ap_id
+      )
+      prefix_log(message)
+    end
+
+    context "when the actor is ready" do
+      before do
+        toggle_activity_pub(category, callbacks: true, publication_type: "full_topic")
       end
 
-      context "with full_topic enabled" do
-        before do
-          toggle_activity_pub(category, callbacks: true, publication_type: "full_topic")
+      context "when not following the target actor" do
+        before { setup_logging }
+        after { teardown_logging }
+
+        it "does not perform any requests" do
+          described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+          DiscourseActivityPub::Request
+            .expects(:get_json_ld)
+            .never
         end
 
-        context "with new activities" do
+        it "logs the right warning" do
+          described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+          expect(@fake_logger.warnings.first).to eq(build_warning_log("not_following_target"))
+        end
+      end
+
+      context "when following the target actor" do
+        let!(:follow1) do
+          Fabricate(:discourse_activity_pub_follow, follower: actor, followed: target_actor)
+        end
+
+        context "when target actor does not return an outbox collection" do
+          before { setup_logging }
+          after { teardown_logging }
+  
           before do
             DiscourseActivityPub::Request
               .expects(:get_json_ld)
-              .with(uri: person1.outbox)
+              .with(uri: target_actor.outbox)
+              .returns(nil)
+          end
+
+          it "does not process any activities" do
+            DiscourseActivityPub::AP::Activity
+              .expects(:process)
+              .never
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+          end
+  
+          it "logs the right warning" do
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+            expect(@fake_logger.warnings.first).to eq(build_warning_log("failed_to_retrieve_outbox"))
+          end
+        end
+
+        context "when target actor returns an invalid outbox collection" do
+          let!(:collection_json) {
+            build_collection_json(
+              type: "Collection",
+              items: [
+                create_1_json,
+                create_2_json
+              ]
+            )
+          }        
+
+          before do
+            setup_logging
+            DiscourseActivityPub::Request
+              .expects(:get_json_ld)
+              .with(uri: target_actor.outbox)
+              .returns(collection_json)
+          end
+  
+          after { teardown_logging }
+  
+          it "does not process any activities" do
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+          end
+  
+          it "logs the right warning" do
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+            expect(@fake_logger.warnings.first).to eq(build_warning_log("outbox_response_invalid"))
+          end
+        end
+
+        context "when target actor returns a valid outbox collection" do
+          before do
+            DiscourseActivityPub::Request
+              .expects(:get_json_ld)
+              .with(uri: target_actor.outbox)
               .returns(ordered_collection_json)
             DiscourseActivityPub::Request
               .expects(:get_json_ld)
-              .with(uri: person1.ap_id)
-              .returns(person1.ap.json)
+              .with(uri: target_actor.ap_id)
+              .returns(target_actor.ap.json)
             DiscourseActivityPub::Request
               .expects(:get_json_ld)
               .with(uri: person2_json[:id])
@@ -49,24 +135,24 @@ RSpec.describe DiscourseActivityPub::OutboxImporter do
           end
 
           it "creates the right topic" do
-            described_class.perform(actor_id: category_actor.id, target_actor_id: person1.id)
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
             expect(category.topics.first.title).to eq(object1_json[:name])
           end
 
           it "creates the right posts" do
-            described_class.perform(actor_id: category_actor.id, target_actor_id: person1.id)
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
             posts = category.topics.first.posts
             expect(posts.first.raw).to eq(object1_json[:content])
             expect(posts.second.raw).to eq(object2_json[:content])
           end
 
           it "creates the right actors" do
-            described_class.perform(actor_id: category_actor.id, target_actor_id: person1.id)
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
             expect(DiscourseActivityPubActor.exists?(ap_id: person2_json[:id]))
           end
 
           it "creates the right activities" do
-            described_class.perform(actor_id: category_actor.id, target_actor_id: person1.id)
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
             expect(
               DiscourseActivityPubActor.exists?(
                 ap_id: [
@@ -82,13 +168,13 @@ RSpec.describe DiscourseActivityPub::OutboxImporter do
             after { teardown_logging }
     
             it "logs the right info" do
-              described_class.perform(actor_id: category_actor.id, target_actor_id: person1.id)
+              described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
               expect(@fake_logger.info.first).to eq(
                 prefix_log(
                   I18n.t(
                     "discourse_activity_pub.import.info.import_started",
-                    actor_id: category_actor.ap_id,
-                    target_actor_id: person1.ap_id
+                    actor_id: actor.ap_id,
+                    target_actor_id: target_actor.ap_id
                   )
                 )
               )

--- a/spec/lib/discourse_activity_pub/outbox_importer_spec.rb
+++ b/spec/lib/discourse_activity_pub/outbox_importer_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseActivityPub::OutboxImporter do
+  let!(:person1) { Fabricate(:discourse_activity_pub_actor_person, local: false) }
+  let!(:person2_json) { build_actor_json }
+  let!(:object1_json) { build_object_json(name: "My cool title", attributed_to: person1) }
+  let!(:object2_json) { build_object_json(in_reply_to: object1_json[:id], attributed_to: person2_json[:id]) }
+  let!(:create_1_json) { build_activity_json(actor: person1, object: object1_json, type: "Create") }
+  let!(:create_2_json) { build_activity_json(actor: person2_json[:id], object: object2_json, type: "Create") }
+  let!(:ordered_collection_json) do
+    build_collection_json(
+      type: "OrderedCollection",
+      items: [
+        create_1_json,
+        create_2_json
+      ]
+    )
+  end
+
+  describe "#perform" do
+
+    context "with a category actor following a remote actor" do
+      let!(:category) { Fabricate(:category) }
+      let!(:category_actor) { Fabricate(:discourse_activity_pub_actor_group, model: category) }
+      let!(:follow1) do
+        Fabricate(:discourse_activity_pub_follow, follower: category_actor, followed: person1)
+      end
+
+      context "with full_topic enabled" do
+        before do
+          toggle_activity_pub(category, callbacks: true, publication_type: "full_topic")
+        end
+
+        context "with new activities" do
+          before do
+            DiscourseActivityPub::Request
+              .expects(:get_json_ld)
+              .with(uri: person1.outbox)
+              .returns(ordered_collection_json)
+            DiscourseActivityPub::Request
+              .expects(:get_json_ld)
+              .with(uri: person1.ap_id)
+              .returns(person1.ap.json)
+            DiscourseActivityPub::Request
+              .expects(:get_json_ld)
+              .with(uri: person2_json[:id])
+              .returns(person2_json)
+              .twice
+          end
+
+          it "creates the right topic" do
+            described_class.perform(actor_id: category_actor.id, target_actor_id: person1.id)
+            expect(category.topics.first.title).to eq(object1_json[:name])
+          end
+
+          it "creates the right posts" do
+            described_class.perform(actor_id: category_actor.id, target_actor_id: person1.id)
+            posts = category.topics.first.posts
+            expect(posts.first.raw).to eq(object1_json[:content])
+            expect(posts.second.raw).to eq(object2_json[:content])
+          end
+
+          it "creates the right actors" do
+            described_class.perform(actor_id: category_actor.id, target_actor_id: person1.id)
+            expect(DiscourseActivityPubActor.exists?(ap_id: person2_json[:id]))
+          end
+
+          it "creates the right activities" do
+            described_class.perform(actor_id: category_actor.id, target_actor_id: person1.id)
+            expect(
+              DiscourseActivityPubActor.exists?(
+                ap_id: [
+                  create_1_json[:id],
+                  create_2_json[:id]
+                ]
+              )
+            )
+          end
+
+          context "with verbose logging enabled" do
+            before { setup_logging }
+            after { teardown_logging }
+    
+            it "logs the right info" do
+              described_class.perform(actor_id: category_actor.id, target_actor_id: person1.id)
+              expect(@fake_logger.info.first).to eq(
+                prefix_log(
+                  I18n.t(
+                    "discourse_activity_pub.import.info.import_started",
+                    actor_id: category_actor.ap_id,
+                    target_actor_id: person1.ap_id
+                  )
+                )
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/discourse_activity_pub/outbox_importer_spec.rb
+++ b/spec/lib/discourse_activity_pub/outbox_importer_spec.rb
@@ -2,43 +2,47 @@
 
 RSpec.describe DiscourseActivityPub::OutboxImporter do
   let!(:category) { Fabricate(:category) }
-  let!(:target_actor) { Fabricate(:discourse_activity_pub_actor_person, local: false) }
+  let!(:target_user) { Fabricate(:user) }
+  let!(:target_actor) do
+    Fabricate(:discourse_activity_pub_actor_person, local: false, model: target_user)
+  end
   let!(:person2_json) { build_actor_json }
   let!(:object1_json) { build_object_json(name: "My cool title", attributed_to: target_actor) }
-  let!(:object2_json) { build_object_json(in_reply_to: object1_json[:id], attributed_to: person2_json[:id]) }
-  let!(:create_1_json) { build_activity_json(actor: target_actor, object: object1_json, type: "Create") }
-  let!(:create_2_json) { build_activity_json(actor: person2_json[:id], object: object2_json, type: "Create") }
+  let!(:object2_json) do
+    build_object_json(in_reply_to: object1_json[:id], attributed_to: person2_json[:id])
+  end
+  let!(:create_1_json) do
+    build_activity_json(actor: target_actor, object: object1_json, type: "Create")
+  end
+  let!(:create_2_json) do
+    build_activity_json(actor: person2_json[:id], object: object2_json, type: "Create")
+  end
   let!(:ordered_collection_json) do
-    build_collection_json(
-      type: "OrderedCollection",
-      items: [
-        create_1_json,
-        create_2_json
-      ]
-    )
+    build_collection_json(type: "OrderedCollection", items: [create_1_json, create_2_json])
   end
 
   describe "#perform" do
     let!(:actor) { Fabricate(:discourse_activity_pub_actor_group, model: category) }
 
     def build_warning_log(key)
-      message = I18n.t(
-        "discourse_activity_pub.import.warning.import_did_not_start",
-        actor_id: actor.ap_id,
-        target_actor_id: target_actor.ap_id
-      )
-      message += ": " + I18n.t(
-        "discourse_activity_pub.import.warning.#{key}",
-        actor_id: actor.ap_id,
-        target_actor_id: target_actor.ap_id
-      )
+      message =
+        I18n.t(
+          "discourse_activity_pub.import.warning.import_did_not_start",
+          actor: actor.handle,
+          target_actor: target_actor.handle,
+        )
+      message +=
+        ": " +
+          I18n.t(
+            "discourse_activity_pub.import.warning.#{key}",
+            actor: actor.handle,
+            target_actor: target_actor.handle,
+          )
       prefix_log(message)
     end
 
     context "when the actor is ready" do
-      before do
-        toggle_activity_pub(category, callbacks: true, publication_type: "full_topic")
-      end
+      before { toggle_activity_pub(category, callbacks: true, publication_type: "full_topic") }
 
       context "when not following the target actor" do
         before { setup_logging }
@@ -46,9 +50,7 @@ RSpec.describe DiscourseActivityPub::OutboxImporter do
 
         it "does not perform any requests" do
           described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
-          DiscourseActivityPub::Request
-            .expects(:get_json_ld)
-            .never
+          DiscourseActivityPub::Request.expects(:get_json_ld).never
         end
 
         it "logs the right warning" do
@@ -65,7 +67,7 @@ RSpec.describe DiscourseActivityPub::OutboxImporter do
         context "when target actor does not return an outbox collection" do
           before { setup_logging }
           after { teardown_logging }
-  
+
           before do
             DiscourseActivityPub::Request
               .expects(:get_json_ld)
@@ -74,28 +76,20 @@ RSpec.describe DiscourseActivityPub::OutboxImporter do
           end
 
           it "does not process any activities" do
-            DiscourseActivityPub::AP::Activity
-              .expects(:process)
-              .never
+            DiscourseActivityPub::AP::Activity.expects(:process).never
             described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
           end
-  
+
           it "logs the right warning" do
             described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
-            expect(@fake_logger.warnings.first).to eq(build_warning_log("failed_to_retrieve_outbox"))
+            expect(@fake_logger.warnings.first).to eq(build_warning_log("outbox_response_invalid"))
           end
         end
 
         context "when target actor returns an invalid outbox collection" do
-          let!(:collection_json) {
-            build_collection_json(
-              type: "Collection",
-              items: [
-                create_1_json,
-                create_2_json
-              ]
-            )
-          }        
+          let!(:collection_json) do
+            build_collection_json(type: "Collection", items: [create_1_json, create_2_json])
+          end
 
           before do
             setup_logging
@@ -104,20 +98,20 @@ RSpec.describe DiscourseActivityPub::OutboxImporter do
               .with(uri: target_actor.outbox)
               .returns(collection_json)
           end
-  
+
           after { teardown_logging }
-  
+
           it "does not process any activities" do
             described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
           end
-  
+
           it "logs the right warning" do
             described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
             expect(@fake_logger.warnings.first).to eq(build_warning_log("outbox_response_invalid"))
           end
         end
 
-        context "when target actor returns a valid outbox collection" do
+        context "when target actor returns an outbox collection with new activities" do
           before do
             DiscourseActivityPub::Request
               .expects(:get_json_ld)
@@ -134,6 +128,11 @@ RSpec.describe DiscourseActivityPub::OutboxImporter do
               .twice
           end
 
+          it "returns the right result" do
+            result = described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+            expect(result[:success]).to eq([create_1_json[:id], create_2_json[:id]])
+          end
+
           it "creates the right topic" do
             described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
             expect(category.topics.first.title).to eq(object1_json[:name])
@@ -148,35 +147,139 @@ RSpec.describe DiscourseActivityPub::OutboxImporter do
 
           it "creates the right actors" do
             described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
-            expect(DiscourseActivityPubActor.exists?(ap_id: person2_json[:id]))
+            expect(DiscourseActivityPubActor.exists?(ap_id: person2_json[:id])).to eq(true)
           end
 
           it "creates the right activities" do
             described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
             expect(
-              DiscourseActivityPubActor.exists?(
-                ap_id: [
-                  create_1_json[:id],
-                  create_2_json[:id]
-                ]
-              )
-            )
+              DiscourseActivityPubActivity.exists?(ap_id: [create_1_json[:id], create_2_json[:id]]),
+            ).to eq(true)
           end
 
           context "with verbose logging enabled" do
             before { setup_logging }
             after { teardown_logging }
-    
+
             it "logs the right info" do
               described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
               expect(@fake_logger.info.first).to eq(
                 prefix_log(
                   I18n.t(
                     "discourse_activity_pub.import.info.import_started",
-                    actor_id: actor.ap_id,
-                    target_actor_id: target_actor.ap_id
-                  )
-                )
+                    actor: actor.handle,
+                    target_actor: target_actor.handle,
+                    activity_count: 2,
+                  ),
+                ),
+              )
+              expect(@fake_logger.info.second).to eq(
+                prefix_log(
+                  I18n.t(
+                    "discourse_activity_pub.import.info.import_finished",
+                    actor: actor.handle,
+                    target_actor: target_actor.handle,
+                    success_count: 2,
+                  ),
+                ),
+              )
+            end
+          end
+        end
+
+        context "when target actor returns an outbox collection with new and existing activities" do
+          let!(:topic) { Fabricate(:topic, category: category) }
+          let!(:collection) { Fabricate(:discourse_activity_pub_ordered_collection, model: topic) }
+          let!(:post) { Fabricate(:post, topic: topic, user: target_user) }
+          let!(:note) do
+            Fabricate(
+              :discourse_activity_pub_object_note,
+              ap_id: object1_json[:id],
+              local: false,
+              model: post,
+              collection_id: collection.id,
+              attributed_to: target_actor,
+            )
+          end
+          let!(:activity) do
+            Fabricate(:discourse_activity_pub_activity_create, actor: target_actor, object: note)
+          end
+
+          before do
+            activity.ap_id = create_1_json[:id]
+            activity.save!
+
+            DiscourseActivityPub::Request
+              .expects(:get_json_ld)
+              .with(uri: target_actor.outbox)
+              .returns(ordered_collection_json)
+            DiscourseActivityPub::Request
+              .expects(:get_json_ld)
+              .with(uri: target_actor.ap_id)
+              .returns(target_actor.ap.json)
+            DiscourseActivityPub::Request
+              .expects(:get_json_ld)
+              .with(uri: person2_json[:id])
+              .returns(person2_json)
+              .twice
+          end
+
+          it "returns the right result" do
+            result = described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+            expect(result[:success]).to eq([create_2_json[:id]])
+            expect(result[:failure]).to eq([create_1_json[:id]])
+          end
+
+          it "creates the right topic" do
+            topic_count = category.topics.size
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+            expect(category.topics.size).to eq(topic_count)
+          end
+
+          it "creates the right posts" do
+            posts_count = category.topics.first.posts.size
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+            posts = category.topics.first.posts
+            expect(posts.size).to eq(posts_count + 1)
+            expect(posts.second.raw).to eq(object2_json[:content])
+          end
+
+          it "creates the right actors" do
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+            expect(DiscourseActivityPubActor.exists?(ap_id: person2_json[:id])).to eq(true)
+          end
+
+          it "creates the right activities" do
+            described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+            expect(DiscourseActivityPubActivity.exists?(ap_id: [create_2_json[:id]])).to eq(true)
+          end
+
+          context "with verbose logging enabled" do
+            before { setup_logging }
+            after { teardown_logging }
+
+            it "logs the right info" do
+              described_class.perform(actor_id: actor.id, target_actor_id: target_actor.id)
+              expect(@fake_logger.info.first).to eq(
+                prefix_log(
+                  I18n.t(
+                    "discourse_activity_pub.import.info.import_started",
+                    actor: actor.handle,
+                    target_actor: target_actor.handle,
+                    activity_count: 2,
+                  ),
+                ),
+              )
+              expect(@fake_logger.info.second).to eq(
+                prefix_log(
+                  I18n.t(
+                    "discourse_activity_pub.import.info.import_finished",
+                    actor: actor.handle,
+                    target_actor: target_actor.handle,
+                    success_count: 1,
+                    failure_count: 1,
+                  ),
+                ),
               )
             end
           end

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -190,9 +190,10 @@ def build_collection_json(type: "Collection", items: [], to: nil, cc: nil, audie
   _json = {
     "@context": "https://www.w3.org/ns/activitystreams",
     id: "https://external.com/collection/#{SecureRandom.hex(8)}",
-    type: type,
-    items: items,
+    type: type
   }
+  _json[:items] = items if type == "Collection"
+  _json[:orderedItems] = items if type == "OrderedCollection"
   _json[:to] = to if to
   _json[:cc] = cc if cc
   _json[:audience] = audience if audience
@@ -202,7 +203,11 @@ end
 def build_process_warning(key, object_id)
   action = I18n.t("discourse_activity_pub.process.warning.failed_to_process", object_id: object_id)
   message = I18n.t("discourse_activity_pub.process.warning.#{key}")
-  "[Discourse Activity Pub] #{action}: #{message}"
+  prefix_log("#{action}: #{message}")
+end
+
+def prefix_log(message)
+  "[Discourse Activity Pub] #{message}"
 end
 
 def perform_process(json, delivered_to = nil)

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -190,10 +190,11 @@ def build_collection_json(type: "Collection", items: [], to: nil, cc: nil, audie
   _json = {
     "@context": "https://www.w3.org/ns/activitystreams",
     id: "https://external.com/collection/#{SecureRandom.hex(8)}",
-    type: type
+    type: type,
   }
   _json[:items] = items if type == "Collection"
   _json[:orderedItems] = items if type == "OrderedCollection"
+  _json[:totalItems] = items.size
   _json[:to] = to if to
   _json[:cc] = cc if cc
   _json[:audience] = audience if audience


### PR DESCRIPTION
@pmusaraj This is the most basic version of the import of prior activities of a new follow (i.e. "outbox import"). As discussed, it's a rake task. I've added two rake tasks actually. I'll give some notes on each.

### activity_pub:import_outbox
This is the import task. The arguments are:
- Actor (handle, ap_Id, or id): this is the actor who will received the imported activities (i.e. a category where the imported posts will appear).
- Target Actor (handle, ap_Id, or id): this is the actor from whom the activities are being imported from. The Actor has to be following the Target Actor to import their outbox.
- Log type (optional: "warn"): The AP logger has been set up to give print descriptive logs about what's going on to stdout, in addition to its normal logging. The default log type is "info", which will print info or error messages to stdout. It will not print process warnings (e.g. see below)

#### Example
```
rake "activity_pub:import_outbox[general@angus.ngrok.io,general@angus.thepavilion.io]"
```
This will import activities in outbox of `general@angus.thepavilion.io`, the AP handle of a category on one Discourse ("Discourse 1") on my local, to `general@angus.ngrok.io`, the AP handle of a category on another Discourse ("Discourse 2") on my local. This is what it looks like.

<img width="867" alt="Screenshot 2024-02-21 at 15 21 50" src="https://github.com/discourse/discourse-activity-pub/assets/5931623/fcaa1908-23a2-4265-9116-6a6d1decd25a">

The table you're seeing that is the "info" printout you'll see if any new activities are imported, giving you a snapshot of the object that have been created. It's the same function as the `activity_pub:info` task (see below) uses.

It only imported 4 out of 48 activities in the outbox because the other 44 already existed on Discourse 2. I ran the same command again, but with the log level set to "warn", and this was the result.

<img width="1083" alt="Screenshot 2024-02-21 at 15 22 54" src="https://github.com/discourse/discourse-activity-pub/assets/5931623/b6e76aab-bbaf-4f77-ba2d-e58144aac8b9">

With the log level set to "warn" I am now seeing why all 48 activities are not being imported the second time it's being run: the activities have already been imported.

### activity_pub:info
Given an ActivityPub ID (e.g. `https://mastodon.pavilion.tech/users/angus/statuses/111432292558317535/activity`) this will tell you whether the AP object exists on this server, what kind of object it is and what Discourse objects it's connected to. This can be useful for debugging purposes, as the ActivityPub ID is typically what is added to logged warnings or errors.

#### Example
I go to import the outbox of my mastodon account, which I've just re-followed.
```
rake "activity_pub:import_outbox[general@angus.ngrok.io,angus@mastodon.pavilion.tech,warn]"
```
I get this result
<img width="1124" alt="Screenshot 2024-02-21 at 16 14 46" src="https://github.com/discourse/discourse-activity-pub/assets/5931623/84064a6f-135a-4ce2-8eee-87916a6fe84b">

I can use the `info` task to see more about my local record of the activities that have already been imported.

<img width="1003" alt="Screenshot 2024-02-21 at 16 16 03" src="https://github.com/discourse/discourse-activity-pub/assets/5931623/e234d6df-abe7-49a8-85cb-2414f38efe00">

### Next steps

I say this is the the most basic version as, even though it works in the way I've described above, there's still work to be done on this during this phase, specifically I'll be adding:

1. Collection pagination to the collections we serialize from our outboxes.
2. Proper handling of pagination in collection processing (Mastodon paginates their outboxes, and currently we're not handling that properly).
3. Pre-processing filtering of previously imported activities, i.e. it will be significantly more efficient to just filter out the previously imported activities in a single query rather than validate (and reject) each one.

Specifically, this basic version is only properly tested with Discourse to Discourse outbox imports. I'm giving this to you now as it does work for that use case, it'll give you a chance to test and request changes, and I'm trying to avoid big PRs.