### PR TITLE
Send out activity json with the right content type

### DIFF
--- a/app/controllers/discourse_activity_pub/ap/activities_controller.rb
+++ b/app/controllers/discourse_activity_pub/ap/activities_controller.rb
@@ -6,7 +6,7 @@ class DiscourseActivityPub::AP::ActivitiesController < DiscourseActivityPub::AP:
   before_action :ensure_can_access_activity_object_model
 
   def show
-    render json: @activity.ap.json
+    render_activity_json(@activity.ap.json)
   end
 
   protected

--- a/app/controllers/discourse_activity_pub/ap/actors_controller.rb
+++ b/app/controllers/discourse_activity_pub/ap/actors_controller.rb
@@ -7,7 +7,7 @@ class DiscourseActivityPub::AP::ActorsController < DiscourseActivityPub::AP::Obj
   before_action :ensure_actor_ready
 
   def show
-    render json: @actor.ap.json
+    render_activity_json(@actor.ap.json)
   end
 
   protected

--- a/app/controllers/discourse_activity_pub/ap/collections_controller.rb
+++ b/app/controllers/discourse_activity_pub/ap/collections_controller.rb
@@ -5,7 +5,7 @@ class DiscourseActivityPub::AP::CollectionsController < DiscourseActivityPub::AP
   before_action :ensure_can_access_collection
 
   def show
-    render json: @collection.ap.json
+    render_activity_json(@collection.ap.json)
   end
 
   protected

--- a/app/controllers/discourse_activity_pub/ap/objects_controller.rb
+++ b/app/controllers/discourse_activity_pub/ap/objects_controller.rb
@@ -19,7 +19,7 @@ class DiscourseActivityPub::AP::ObjectsController < ApplicationController
   before_action :set_raw_body
 
   def show
-    render json: @object.ap.json
+    render_activity_json(@object.ap.json)
   end
 
   protected
@@ -90,6 +90,10 @@ class DiscourseActivityPub::AP::ObjectsController < ApplicationController
     end
   end
 
+  def render_activity_json(json)
+    render json: json, content_type: DiscourseActivityPub::JsonLd::ACTIVITY_CONTENT_TYPE
+  end
+
   def render_activity_pub_error(key, status, opts = {})
     message = I18n.t("discourse_activity_pub.request.error.#{key}", opts)
     log_request_error(message, status)
@@ -101,11 +105,12 @@ class DiscourseActivityPub::AP::ObjectsController < ApplicationController
       DiscourseActivityPub::AP::Collection::OrderedCollection.new(
         stored: stored.send("#{collection_for}_collection"),
       )
-    render json:
-             DiscourseActivityPub::AP::Collection::OrderedCollectionSerializer.new(
-               collection,
-               root: false,
-             ).as_json
+    render_activity_json(
+      DiscourseActivityPub::AP::Collection::OrderedCollectionSerializer.new(
+        collection,
+        root: false,
+      ).as_json,
+    )
   end
 
   def set_raw_body

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -292,3 +292,7 @@ def teardown_logging
   Rails.logger = @orig_logger
   SiteSetting.activity_pub_verbose_logging = false
 end
+
+def parsed_body
+  JSON.parse(response.body)
+end

--- a/spec/requests/discourse_activity_pub/ap/activities_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/activities_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe DiscourseActivityPub::AP::ActivitiesController do
     it "returns activity json" do
       get_object(activity)
       expect(response.status).to eq(200)
-      expect(response.parsed_body).to eq(activity.ap.json)
+      expect(parsed_body).to eq(activity.ap.json)
     end
 
     context "with publishing disabled" do
@@ -81,7 +81,7 @@ RSpec.describe DiscourseActivityPub::AP::ActivitiesController do
         it "returns activity json" do
           get_object(activity)
           expect(response.status).to eq(200)
-          expect(response.parsed_body).to eq(activity.ap.json)
+          expect(parsed_body).to eq(activity.ap.json)
         end
       end
 
@@ -91,7 +91,7 @@ RSpec.describe DiscourseActivityPub::AP::ActivitiesController do
         it "returns activity json" do
           get_object(activity)
           expect(response.status).to eq(200)
-          expect(response.parsed_body).to eq(activity.ap.json)
+          expect(parsed_body).to eq(activity.ap.json)
         end
       end
 
@@ -101,7 +101,7 @@ RSpec.describe DiscourseActivityPub::AP::ActivitiesController do
         it "returns activity json" do
           get_object(activity)
           expect(response.status).to eq(200)
-          expect(response.parsed_body).to eq(activity.ap.json)
+          expect(parsed_body).to eq(activity.ap.json)
         end
       end
     end

--- a/spec/requests/discourse_activity_pub/ap/actors_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/actors_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe DiscourseActivityPub::AP::ActorsController do
         it "returns actor json" do
           get_object(group)
           expect(response.status).to eq(200)
-          expect(response.parsed_body).to eq(group.ap.json)
+          expect(parsed_body).to eq(group.ap.json)
         end
       end
 
@@ -61,7 +61,7 @@ RSpec.describe DiscourseActivityPub::AP::ActorsController do
         it "returns actor json" do
           get_object(application)
           expect(response.status).to eq(200)
-          expect(response.parsed_body).to eq(application.ap.json)
+          expect(parsed_body).to eq(application.ap.json)
         end
       end
 
@@ -79,7 +79,7 @@ RSpec.describe DiscourseActivityPub::AP::ActorsController do
     it "returns actor json" do
       get_object(group)
       expect(response.status).to eq(200)
-      expect(response.parsed_body).to eq(group.ap.json)
+      expect(parsed_body).to eq(group.ap.json)
     end
   end
 end

--- a/spec/requests/discourse_activity_pub/ap/collections_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/collections_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe DiscourseActivityPub::AP::CollectionsController do
     it "returns collection json" do
       get_object(collection)
       expect(response.status).to eq(200)
-      expect(response.parsed_body).to eq(collection.ap.json)
+      expect(parsed_body).to eq(collection.ap.json)
     end
   end
 end

--- a/spec/requests/discourse_activity_pub/ap/followers_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/followers_controller_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe DiscourseActivityPub::AP::FollowersController do
     it "returns an ordered collection of the actors followers" do
       get_followers(actor)
       expect(response.status).to eq(200)
-      expect(response.parsed_body["totalItems"]).to eq(3)
-      expect(response.parsed_body["orderedItems"][0]["id"]).to eq(follower3.ap_id)
-      expect(response.parsed_body["orderedItems"][1]["id"]).to eq(follower1.ap_id)
-      expect(response.parsed_body["orderedItems"][2]["id"]).to eq(follower2.ap_id)
+      expect(parsed_body["totalItems"]).to eq(3)
+      expect(parsed_body["orderedItems"][0]["id"]).to eq(follower3.ap_id)
+      expect(parsed_body["orderedItems"][1]["id"]).to eq(follower1.ap_id)
+      expect(parsed_body["orderedItems"][2]["id"]).to eq(follower2.ap_id)
     end
   end
 end

--- a/spec/requests/discourse_activity_pub/ap/objects_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/objects_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe DiscourseActivityPub::AP::ObjectsController do
     it "returns a object json" do
       get_object(object)
       expect(response.status).to eq(200)
-      expect(response.parsed_body).to eq(object.ap.json)
+      expect(parsed_body).to eq(object.ap.json)
     end
   end
 end

--- a/spec/requests/discourse_activity_pub/ap/outboxes_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/outboxes_controller_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe DiscourseActivityPub::AP::OutboxesController do
     it "returns an ordered collection of the actors activities" do
       get_from_outbox(actor)
       expect(response.status).to eq(200)
-      expect(response.parsed_body["totalItems"]).to eq(3)
-      expect(response.parsed_body["orderedItems"][0]["id"]).to eq(activity3.ap_id)
-      expect(response.parsed_body["orderedItems"][1]["id"]).to eq(activity1.ap_id)
-      expect(response.parsed_body["orderedItems"][2]["id"]).to eq(activity2.ap_id)
+      expect(parsed_body["totalItems"]).to eq(3)
+      expect(parsed_body["orderedItems"][0]["id"]).to eq(activity3.ap_id)
+      expect(parsed_body["orderedItems"][1]["id"]).to eq(activity1.ap_id)
+      expect(parsed_body["orderedItems"][2]["id"]).to eq(activity2.ap_id)
     end
   end
 end


### PR DESCRIPTION
@pmusaraj This may fix the intermittent Mastodon connection issues.

See https://github.com/mastodon/mastodon/commit/9fee5e852669e26f970e278021302e1a203fc022#diff-f2b81b35ad071b9ed67f7207f23ee5b6323c5bc25923be1764e4ce04c67eb9b3

See also
https://socialhub.activitypub.rocks/t/adding-federation-support-to-discourse/2966/47?u=angus