### PR TITLE
Ensure User Actor usernames are valid for ActivityPub

### DIFF
--- a/app/models/discourse_activity_pub_actor.rb
+++ b/app/models/discourse_activity_pub_actor.rb
@@ -208,7 +208,7 @@ class DiscourseActivityPubActor < ActiveRecord::Base
     sql += " AND local IS TRUE" if local
     args = { username: username }
     args[:model_id] = model_id if model_id
-    self.where(sql, args).exists?
+    !self.where(sql, args).exists?
   end
 
   # Equivalent of mastodon/mastodon/app/models/concerns/account_finder_concern.rb#representative

--- a/extensions/discourse_activity_pub_category_extension.rb
+++ b/extensions/discourse_activity_pub_category_extension.rb
@@ -27,7 +27,7 @@ module DiscourseActivityPubCategoryExtension
         DiscourseActivityPub::UsernameValidator.perform_validation(self, "activity_pub_username")
 
         if self.errors.blank? &&
-             DiscourseActivityPubActor.username_unique?(
+             !DiscourseActivityPubActor.username_unique?(
                @custom_fields["activity_pub_username"],
                model_id: self.id,
              )

--- a/lib/discourse_activity_pub/user_handler.rb
+++ b/lib/discourse_activity_pub/user_handler.rb
@@ -90,7 +90,13 @@ module DiscourseActivityPub
     end
 
     def update_actor
-      actor.username = user.username
+      username = user.username
+
+      if !UsernameValidator.new(username).valid_format?
+        username = UsernameSuggester.suggest(username)
+      end
+
+      actor.username = username
       actor.name = user.name if user.name
     end
 

--- a/lib/discourse_activity_pub/username_suggester.rb
+++ b/lib/discourse_activity_pub/username_suggester.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module DiscourseActivityPub
+  class UsernameSuggester
+    LAST_RESORT_USERNAME = "actor"
+
+    def self.suggest(username)
+      username = normalize(username)
+      username = normalize(I18n.t("fallback_username")) if username.blank?
+      username = LAST_RESORT_USERNAME if username.blank?
+
+      find_available(username)
+    end
+
+    def self.normalize(text)
+      text.unicode_normalize(:nfkd).encode("ASCII", replace: "")
+    end
+
+    # Based on discourse/discourse/lib/user_name_suggester.rb#find_available_username_based_on
+    def self.find_available(username)
+      return username if DiscourseActivityPubActor.username_unique?(username)
+
+      similar = "#{username}(0|1|2|3|4|5|6|7|8|9)+"
+      count = DB.query_single(<<~SQL, like: "#{username}%", similar: similar).first
+        SELECT count(*) FROM discourse_activity_pub_actors
+        WHERE local IS TRUE
+        AND username LIKE :like
+        AND username SIMILAR TO :similar
+      SQL
+
+      offset =
+        if count > 0
+          params = { count: count + 10, username: username }
+          available = DB.query_single(<<~SQL, params).first
+          WITH numbers AS (SELECT generate_series(1, :count) AS n)
+          SELECT n FROM numbers
+          LEFT JOIN discourse_activity_pub_actors ON (
+            username = :username || n::varchar
+          ) AND (
+            local IS TRUE
+          )
+          WHERE discourse_activity_pub_actors.id IS NULL
+          ORDER by n ASC
+          LIMIT 1
+        SQL
+          [available.to_i - 1, 0].max
+        else
+          0
+        end
+
+      i = 1
+      attempt = username
+      until (DiscourseActivityPubActor.username_unique?(attempt) || i > 100)
+        suffix = (i + offset).to_s
+        max_length = User.username_length.end - suffix.length
+        attempt = "#{UserNameSuggester.truncate(username, max_length)}#{suffix}"
+        i += 1
+      end
+
+      attempt
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -19,6 +19,7 @@ after_initialize do
     ../lib/discourse_activity_pub/request.rb
     ../lib/discourse_activity_pub/webfinger.rb
     ../lib/discourse_activity_pub/username_validator.rb
+    ../lib/discourse_activity_pub/username_suggester.rb
     ../lib/discourse_activity_pub/content_parser.rb
     ../lib/discourse_activity_pub/signature_parser.rb
     ../lib/discourse_activity_pub/delivery_failure_tracker.rb

--- a/spec/lib/discourse_activity_pub/user_handler_spec.rb
+++ b/spec/lib/discourse_activity_pub/user_handler_spec.rb
@@ -200,5 +200,18 @@ RSpec.describe DiscourseActivityPub::UserHandler do
         expect(DiscourseActivityPubActor.all.size).to eq(actor_count)
       end
     end
+
+    context "when user has a username that would be invalid as an ActivityPub username" do
+      before do
+        SiteSetting.unicode_usernames = true
+        user.username = "óengus"
+        user.save!
+      end
+
+      it "creates an actor with a valid ActivityPub username" do
+        actor = described_class.update_or_create_actor(user)
+        expect(actor.username).to eq("oengus")
+      end
+    end
   end
 end

--- a/spec/lib/discourse_activity_pub/username_suggester_spec.rb
+++ b/spec/lib/discourse_activity_pub/username_suggester_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseActivityPub::UsernameSuggester do
+  describe "#suggest" do
+    it "converts non-valid usernames to valid usernames" do
+      expect(described_class.suggest("零卡")).to eq(I18n.t("fallback_username"))
+    end
+
+    it "works with non-latin locales" do
+      expect(I18n.with_locale(:zh_TW) { described_class.suggest("零卡") }).to eq(
+        described_class::LAST_RESORT_USERNAME,
+      )
+    end
+
+    it "returns locally unique usernames" do
+      expect(described_class.suggest("à")).to eq("a")
+      Fabricate(:discourse_activity_pub_actor, username: "a", local: true)
+      expect(described_class.suggest("à")).to eq("a1")
+      Fabricate(:discourse_activity_pub_actor, username: "a1", local: true)
+      expect(described_class.suggest("à")).to eq("a2")
+      Fabricate(:discourse_activity_pub_actor, username: "a2", local: false)
+      Fabricate(:discourse_activity_pub_actor, username: "a10", local: true)
+      expect(described_class.suggest("à")).to eq("a2")
+      expect(described_class.suggest("a10")).to eq("a101")
+    end
+  end
+end


### PR DESCRIPTION
@pmusaraj This ensures user actor usernames are valid for ActivityPub (ASCII), regardless of what kind of usernames the Discourse instance supports.

See further: https://meta.discourse.org/t/activitypub-plugin/266794/158?u=angus