### PR TITLE
Add site setting to control post status indicator visibility

### DIFF
--- a/assets/javascripts/discourse/initializers/activity-pub-initializer.js
+++ b/assets/javascripts/discourse/initializers/activity-pub-initializer.js
@@ -1,6 +1,7 @@
 import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { AUTO_GROUPS } from "discourse/lib/constants";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { bind } from "discourse-common/utils/decorators";
 
@@ -52,6 +53,21 @@ export default {
 
       // TODO (future): PR discourse/discourse to add post infos via api
       api.reopenWidget("post-meta-data", {
+        showStatusToUser(user) {
+          if (!user) {
+            return false;
+          }
+          const groupIds =
+            this.siteSettings.activity_pub_post_status_visibility_groups
+              .split("|")
+              .map(Number);
+          return user.groups.some(
+            (group) =>
+              groupIds.includes(AUTO_GROUPS.everyone.id) ||
+              groupIds.includes(group.id)
+          );
+        },
+
         html(attrs) {
           const result = this._super(attrs);
           let postStatuses = result[result.length - 1].children;
@@ -61,7 +77,7 @@ export default {
           if (
             site.activity_pub_enabled &&
             attrs.activity_pub_enabled &&
-            currentUser?.staff
+            this.showStatusToUser(this.currentUser)
           ) {
             let time;
             let state;

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -161,3 +161,4 @@ en:
     activity_pub_delivery_delay_minutes: "Number of minutes to delay delivery of ActivityPub activities ('delete' activities are delivered instantly)."
     activity_pub_verbose_logging: "Enable verbose ActivityPub logs."
     activity_pub_object_logging: "Print all incoming and outgoing ActivityPub objects in the logs (requires verbose logging)."
+    activity_pub_post_status_visibility_groups: "Groups who can see ActivityPub post statuses."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,7 +25,7 @@ discourse_activity_pub:
     min: 1
     client: true
   activity_pub_post_status_visibility_groups:
-    default: "1|3|14" # auto group admin, staff, and trust_level_4
+    default: "0" # everyone
     type: group_list
     allow_any: false
     refresh: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,6 +24,12 @@ discourse_activity_pub:
     default: 5
     min: 1
     client: true
+  activity_pub_post_status_visibility_groups:
+    default: "1|3|14" # auto group admin, staff, and trust_level_4
+    type: group_list
+    allow_any: false
+    refresh: true
+    client: true
   activity_pub_verbose_logging:
     default: false
   activity_pub_object_logging:

--- a/test/javascripts/acceptance/activity-pub-topic-test.js
+++ b/test/javascripts/acceptance/activity-pub-topic-test.js
@@ -47,6 +47,7 @@ acceptance(
     });
 
     test("ActivityPub indicator element", async function (assert) {
+      this.siteSettings.activity_pub_post_status_visibility_groups = "1";
       Site.current().set("activity_pub_enabled", true);
 
       await visit("/t/280");
@@ -70,6 +71,7 @@ acceptance(
     });
 
     test("When the plugin is disabled", async function (assert) {
+      this.siteSettings.activity_pub_post_status_visibility_groups = "2";
       Site.current().setProperties({
         activity_pub_enabled: false,
         activity_pub_publishing_enabled: false,
@@ -84,6 +86,7 @@ acceptance(
     });
 
     test("ActivityPub indicator element", async function (assert) {
+      this.siteSettings.activity_pub_post_status_visibility_groups = "2";
       Site.current().setProperties({
         activity_pub_enabled: true,
         activity_pub_publishing_enabled: true,

--- a/test/javascripts/acceptance/activity-pub-topic-test.js
+++ b/test/javascripts/acceptance/activity-pub-topic-test.js
@@ -1,5 +1,6 @@
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import { AUTO_GROUPS } from "discourse/lib/constants";
 import Site from "discourse/models/site";
 import topicFixtures from "discourse/tests/fixtures/topic";
 import {
@@ -34,9 +35,13 @@ const setupServer = (needs, attrs = {}) => {
 };
 
 acceptance(
-  "Discourse Activity Pub | ActivityPub topic as user",
+  "Discourse Activity Pub | ActivityPub topic as user with post status not visible",
   function (needs) {
-    needs.user({ moderator: false, admin: false });
+    needs.user({
+      moderator: false,
+      admin: false,
+      groups: [AUTO_GROUPS.trust_level_0, AUTO_GROUPS.trust_level_1],
+    });
     setupServer(needs, {
       activity_pub_published_at: publishedAt,
     });
@@ -55,7 +60,7 @@ acceptance(
 );
 
 acceptance(
-  "Discourse Activity Pub | ActivityPub topic as staff",
+  "Discourse Activity Pub | ActivityPub topic as user in a group with post status visible",
   function (needs) {
     needs.user({ moderator: true, admin: false });
     setupServer(needs, {


### PR DESCRIPTION
@pmusaraj This is to allow for circumstances where users want more insight into the ActivityPub status of a note. This has come up a few times in testing with users.