### PR TITLE
Add post object ap id to post modal

### DIFF
--- a/assets/javascripts/discourse/components/modal/activity-pub-post-info.hbs
+++ b/assets/javascripts/discourse/components/modal/activity-pub-post-info.hbs
@@ -33,7 +33,8 @@
             <DButton
               @icon="check"
               @title="ip_lookup.copied"
-              class="activity-pub-object-id-copy success">
+              class="activity-pub-object-id-copy success"
+            >
               <div class="activity-pub-object-id-copy-text">
                 {{i18n "post.controls.link_copied"}}
               </div>
@@ -42,7 +43,8 @@
             <DButton
               @action={{this.copyObjectId}}
               @icon="copy"
-              class="no-text activity-pub-object-id-copy" />
+              class="no-text activity-pub-object-id-copy"
+            />
           {{/if}}
         </span>
       {{/if}}

--- a/assets/javascripts/discourse/components/modal/activity-pub-post-info.hbs
+++ b/assets/javascripts/discourse/components/modal/activity-pub-post-info.hbs
@@ -25,6 +25,27 @@
           </a>
         </span>
       {{/if}}
+      {{#if showObjectId}}
+        <span class="activity-pub-object-id">
+          {{d-icon "link"}}
+          <span>{{@model.post.activity_pub_object_id}}</span>
+          {{#if this.copiedObjectId}}
+            <DButton
+              @icon="check"
+              @title="ip_lookup.copied"
+              class="activity-pub-object-id-copy success">
+              <div class="activity-pub-object-id-copy-text">
+                {{i18n "post.controls.link_copied"}}
+              </div>
+            </DButton>
+          {{else}}
+            <DButton
+              @action={{this.copyObjectId}}
+              @icon="copy"
+              class="no-text activity-pub-object-id-copy" />
+          {{/if}}
+        </span>
+      {{/if}}
     </div>
   </:body>
 </DModal>

--- a/assets/javascripts/discourse/components/modal/activity-pub-post-info.js
+++ b/assets/javascripts/discourse/components/modal/activity-pub-post-info.js
@@ -1,7 +1,21 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { clipboardCopy } from "discourse/lib/utilities";
 import I18n from "I18n";
 
 export default class ActivityPubPostInfo extends Component {
+  @tracked copiedObjectId = false;
+
+  @action
+  copyObjectId() {
+    clipboardCopy(this.args.model.post.activity_pub_object_id);
+    this.copiedObjectId = true;
+    setTimeout(() => {
+      this.copiedObjectId = false;
+    }, 2500);
+  }
+
   get title() {
     return I18n.t("post.discourse_activity_pub.info.title", {
       post_number: this.args.model.post.post_number,
@@ -63,5 +77,9 @@ export default class ActivityPubPostInfo extends Component {
       !this.args.model.post.activity_pub_local &&
       this.args.model.post.activity_pub_url
     );
+  }
+
+  get showObjectId() {
+    return this.args.model.post.activity_pub_local;
   }
 }

--- a/assets/javascripts/discourse/initializers/activity-pub-initializer.js
+++ b/assets/javascripts/discourse/initializers/activity-pub-initializer.js
@@ -49,6 +49,10 @@ export default {
         "activity_pub_is_first_post",
         "activity_pub_is_first_post"
       );
+      api.includePostAttributes(
+        "activity_pub_object_id",
+        "activity_pub_object_id"
+      );
       api.serializeOnCreate("activity_pub_visibility");
 
       // TODO (future): PR discourse/discourse to add post infos via api

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -188,7 +188,38 @@ a.activity-pub-site-setting-label {
   a {
     display: flex;
     align-items: center;
-    gap: 0.5em;
+    gap: 1em;
+    min-height: 35px;
+  }
+
+  button {
+    height: 100%;
+  }
+}
+
+.activity-pub-object-id {
+  > span {
+    white-space: nowrap;
+    max-width: 90%;
+    overflow: hidden;
+  }
+
+  .activity-pub-object-id-copy {
+    position: relative;
+
+    .activity-pub-object-id-copy-text {
+      position: absolute;
+      top: -25px;
+      width: 90px;
+      left: -30px;
+    }
+  }
+
+  .activity-pub-object-id-copy.success {
+    .d-icon,
+    .activity-pub-object-id-copy-text {
+      color: var(--success);
+    }
   }
 }
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -524,6 +524,7 @@ after_initialize do
   add_to_class(:post, :activity_pub_topic_trashed) do
     @activity_pub_topic_trashed ||= Topic.with_deleted.find_by(id: self.topic_id)
   end
+  add_to_class(:post, :activity_pub_object_id) { activity_pub_local? && activity_pub_object&.ap_id }
 
   add_to_serializer(:post, :activity_pub_enabled) { object.activity_pub_enabled }
   activity_pub_post_custom_field_names.each do |field_name|
@@ -563,6 +564,11 @@ after_initialize do
     :activity_pub_is_first_post,
     include_condition: -> { object.activity_pub_enabled },
   ) { object.activity_pub_is_first_post? }
+  add_to_serializer(
+    :post,
+    :activity_pub_object_id,
+    include_condition: -> { object.activity_pub_enabled },
+  ) { object.activity_pub_object_id }
 
   TopicView.on_preload do |topic_view|
     if topic_view.topic.activity_pub_enabled


### PR DESCRIPTION
@pmusaraj This adds the post object id to the AP post modal (when the post is local), as it is useful to have access to it in certain situations, e.g. https://socialhub.activitypub.rocks/t/our-next-meeting/4079/4?u=angus