### PR TITLE
Default Note maximum character length to 0 (off)

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -238,7 +238,7 @@ en:
     activity_pub_enabled: "Enable ActivityPub plugin."
     activity_pub_rate_limit_post_to_inbox_per_minute: "Number of POST requests that can be made to an actor's inbox per minute."
     activity_pub_rate_limit_get_objects_per_minute: "Number of GET requests that can be made on AcitivityPub objects per minute."
-    activity_pub_note_excerpt_maxlength: "Maximum length of post excerpts in AcitivityPub Notes."
+    activity_pub_note_excerpt_maxlength: "Maximum length of post excerpts in AcitivityPub Notes (0 for no maximum length)."
     activity_pub_note_link_to_forum: "Include a link to this forum in ActivityPub notes."
     activity_pub_require_signed_requests: "Require ActivityPub requests to be signed with HTTP signatures."
     activity_pub_allowed_request_origins: "List of domains allowed to make ActivityPub requests."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,7 +7,7 @@ discourse_activity_pub:
   activity_pub_rate_limit_get_objects_per_minute:
     default: 20
   activity_pub_note_excerpt_maxlength:
-    default: 500
+    default: 0
   activity_pub_note_link_to_forum:
     default: true
   activity_pub_require_signed_requests:

--- a/lib/discourse_activity_pub/content_parser.rb
+++ b/lib/discourse_activity_pub/content_parser.rb
@@ -98,7 +98,7 @@ class DiscourseActivityPub::ContentParser < Nokogiri::XML::SAX::Document
   end
 
   def characters(string)
-    if @current_length + string.length > @length
+    if @length > 0 && (@current_length + string.length > @length)
       length = [0, @length - @current_length - 1].max
       @content << string[0..length]
       @content << "&hellip;"

--- a/spec/lib/discourse_activity_pub/content_parser_spec.rb
+++ b/spec/lib/discourse_activity_pub/content_parser_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe DiscourseActivityPub::ContentParser do
 
     it "does not apply a maxlength if the site setting is 0" do
       SiteSetting.activity_pub_note_excerpt_maxlength = 0
-      expected_excerpt = "This is a &hellip;"
       post = Fabricate(:post_with_long_raw_content)
       post.rebake!
       expect(described_class.get_content(post)).to eq(

--- a/spec/lib/discourse_activity_pub/content_parser_spec.rb
+++ b/spec/lib/discourse_activity_pub/content_parser_spec.rb
@@ -16,12 +16,22 @@ RSpec.describe DiscourseActivityPub::ContentParser do
   end
 
   describe "#get_content" do
-    it "respects the site setting for note excerpts" do
+    it "respects the maxlength site setting for note excerpts" do
       SiteSetting.activity_pub_note_excerpt_maxlength = 10
       expected_excerpt = "This is a &hellip;"
       post = Fabricate(:post_with_long_raw_content)
       post.rebake!
       expect(described_class.get_content(post)).to eq(expected_excerpt)
+    end
+
+    it "does not apply a maxlength if the site setting is 0" do
+      SiteSetting.activity_pub_note_excerpt_maxlength = 0
+      expected_excerpt = "This is a &hellip;"
+      post = Fabricate(:post_with_long_raw_content)
+      post.rebake!
+      expect(described_class.get_content(post)).to eq(
+        "This is a sample post with semi-long raw content. The raw content is also more than\ntwo hundred characters to satisfy any test conditions that require content longer\nthan the typical test post raw content. It really is some long content, folks.",
+      )
     end
 
     it "respects [note] tags" do


### PR DESCRIPTION
@pmusaraj It turns out that Mastodon will actually process the `content` of _remote_ Notes without limit (not local ones), meaning that our _default_ here should actually be no character limit restriction. See further https://socialhub.activitypub.rocks/t/federating-the-content-of-posts-note-articles-and-character-limits/4087/7?u=angus