### PR TITLE
Support implicit create from group actor announcements

### DIFF
--- a/lib/discourse_activity_pub/ap/actor/group.rb
+++ b/lib/discourse_activity_pub/ap/actor/group.rb
@@ -19,7 +19,7 @@ module DiscourseActivityPub
             create: %i[note article],
             delete: %i[note article],
             update: %i[note article],
-            announce: %i[create update delete like undo ordered_collection],
+            announce: %i[create update delete like undo ordered_collection note article],
             follow: %i[group person],
             undo: [:follow],
           }

--- a/lib/discourse_activity_pub/user_handler.rb
+++ b/lib/discourse_activity_pub/user_handler.rb
@@ -37,7 +37,7 @@ module DiscourseActivityPub
     end
 
     def user
-      @user ||= actor&.model
+      @user ||= actor&.model.is_a?(User) ? actor.model : nil
     end
 
     def actor

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -288,8 +288,10 @@ def expect_no_delivery
 end
 
 def stub_stored_request(object)
-  stub_request(:get, object.ap_id).to_return(
-    body: object.ap.json.to_json,
+  object_id = object.respond_to?(:ap_id) ? object.ap_id : object[:id]
+  object_json = object.respond_to?(:ap) ? object.ap.json : object
+  stub_request(:get, object_id).to_return(
+    body: object_json.to_json,
     headers: {
       "Content-Type" => "application/json",
     },


### PR DESCRIPTION
@pmusaraj This adds support for when a Group actor Announces a Note directly (i.e. an "implicit" create), which is an approach used by some other implementors. We already support implicit Create from Persons.
```
{
  type: "Announce",
  object: "https://community.nodebb.org/posts/1",
  actor: "https://community.nodebb.org/category/2"
  ...
}
```