### PR TITLE
Change successful delivery log level to warn

### DIFF
--- a/app/jobs/discourse_activity_pub_deliver.rb
+++ b/app/jobs/discourse_activity_pub_deliver.rb
@@ -132,7 +132,8 @@ module Jobs
     end
 
     def log_success
-      DiscourseActivityPub::Logger.info(
+      ## TODO: change the severity level back to info once logs are surfaced in ActivityPub admin.
+      DiscourseActivityPub::Logger.warn(
         I18n.t(
           "discourse_activity_pub.deliver.info.successfully_delivered",
           from_actor: from_actor.ap_id,


### PR DESCRIPTION
@pmusaraj This allows for successful deliveries to show in logster (assuming default logster settings). This is temporary measure to help with debugging / integration, until ActivityPub logs are surfaced in the ActivityPub admin panel.