### PR TITLE
Always publish activities individually, even if delayed

### DIFF
--- a/app/models/concerns/discourse_activity_pub/ap/model_callbacks.rb
+++ b/app/models/concerns/discourse_activity_pub/ap/model_callbacks.rb
@@ -130,9 +130,9 @@ module DiscourseActivityPub
       def activity_pub_deliver_activity
         return if !activity_pub_delivery_object
 
-        if activity_pub_schedule?
+        if !self.destroyed? && !activity_pub_published? && !performing_activity.create?
           if self.respond_to?(:activity_pub_after_scheduled)
-            activity_pub_after_scheduled(scheduled_at: activity_pub_first_post_scheduled_at)
+            activity_pub_after_scheduled(scheduled_at: activity_pub_scheduled_at)
           end
           return
         end
@@ -171,11 +171,6 @@ module DiscourseActivityPub
           end
       end
 
-      def activity_pub_schedule?
-        !self.destroyed? && activity_pub_full_topic && !activity_pub_topic_published? &&
-          (!activity_pub_is_first_post? || !performing_activity.create?)
-      end
-
       def activity_pub_delivery_actor
         if performing_activity.create?
           activity_pub_group_actor
@@ -185,11 +180,7 @@ module DiscourseActivityPub
       end
 
       def activity_pub_delivery_object
-        if !self.destroyed? && !activity_pub_topic_published? && activity_pub_full_topic
-          activity_pub_collection.activities_collection
-        else
-          performing_activity.stored
-        end
+        performing_activity.stored
       end
 
       def activity_pub_delivery_delay

--- a/plugin.rb
+++ b/plugin.rb
@@ -584,7 +584,7 @@ after_initialize do
 
   add_to_class(:post_action, :activity_pub_enabled) { post.activity_pub_enabled }
   add_to_class(:post_action, :activity_pub_deleted?) { nil }
-  add_to_class(:post_action, :activity_pub_published?) { nil }
+  add_to_class(:post_action, :activity_pub_published?) { !!post.activity_pub_published_at }
   add_to_class(:post_action, :activity_pub_visibility) { "public" }
   add_to_class(:post_action, :activity_pub_actor) { user.activity_pub_actor }
   add_to_class(:post_action, :activity_pub_group_actor) { post.activity_pub_group_actor }

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -852,10 +852,10 @@ RSpec.describe Post do
               )
             end
 
-            it "sends the topic collection as the topic actor for delayed delivery" do
+            it "sends the activity for delayed delivery" do
               expect_delivery(
                 actor: topic.activity_pub_actor,
-                object: topic.activity_pub_object,
+                object_type: "Create",
                 delay: SiteSetting.activity_pub_delivery_delay_minutes.to_i,
               )
               perform_create
@@ -1176,8 +1176,12 @@ RSpec.describe Post do
             end
 
             context "while not published" do
-              it "does not send anything for delivery" do
-                expect_no_delivery
+              it "sends the activity for delayed delivery" do
+                expect_delivery(
+                  actor: topic.activity_pub_actor,
+                  object_type: "Create",
+                  delay: SiteSetting.activity_pub_delivery_delay_minutes.to_i,
+                )
                 perform_create
               end
             end


### PR DESCRIPTION
@pmusaraj See further https://socialhub.activitypub.rocks/t/publishing-processing-collections-of-activities/4105