### PR TITLE
FIX: Don't create a new topic if it's an orphaned reply

### DIFF
--- a/lib/discourse_activity_pub/post_handler.rb
+++ b/lib/discourse_activity_pub/post_handler.rb
@@ -28,7 +28,7 @@ module DiscourseActivityPub
 
       new_topic = !object.reply_to_id && !topic_id && (category || tag)
       reply_to = object.in_reply_to_post
-      return nil if !new_topic && !reply_to
+      return nil if !import_mode && !new_topic && !reply_to
 
       params = {
         raw: object.content,

--- a/lib/discourse_activity_pub/post_handler.rb
+++ b/lib/discourse_activity_pub/post_handler.rb
@@ -26,7 +26,10 @@ module DiscourseActivityPub
       end
       tag = Tag.find_by(id: tag_id) if tag_id
 
-      new_topic = !object.in_reply_to_post && (category || tag)
+      new_topic = !object.reply_to_id && !topic_id && (category || tag)
+      reply_to = object.in_reply_to_post
+      return nil if !new_topic && !reply_to
+
       params = {
         raw: object.content,
         skip_events: true,
@@ -43,8 +46,9 @@ module DiscourseActivityPub
           DiscourseActivityPub::ContentParser.get_title(object.content)
         params[:category] = category.id if category
         params[:topic_opts] = { tags: [tag.name] } if tag
-      else
-        reply_to = object.in_reply_to_post
+      end
+
+      if reply_to
         params[:topic_id] = reply_to.topic.id
         params[:reply_to_post_number] = reply_to.post_number
       end

--- a/spec/lib/discourse_activity_pub/post_handler_spec.rb
+++ b/spec/lib/discourse_activity_pub/post_handler_spec.rb
@@ -197,6 +197,17 @@ RSpec.describe DiscourseActivityPub::PostHandler do
         expect(object.model_type).to eq("Post")
         expect(object.collection_id).to eq(topic.activity_pub_object.id)
       end
+
+      context "when inReplyTo object is not present" do
+        before do
+          toggle_activity_pub(category, callbacks: true, publication_type: "full_topic")
+          note.destroy!
+        end
+
+        it "does nothing" do
+          expect(described_class.create(user, object, category_id: category.id)).to eq(nil)
+        end
+      end
     end
   end
 end

--- a/spec/lib/discourse_activity_pub/post_handler_spec.rb
+++ b/spec/lib/discourse_activity_pub/post_handler_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe DiscourseActivityPub::PostHandler do
 
       context "when inReplyTo object is not present" do
         before do
-          toggle_activity_pub(category, callbacks: true, publication_type: "full_topic")
+          toggle_activity_pub(category, publication_type: "full_topic")
           note.destroy!
         end
 


### PR DESCRIPTION
@pmusaraj This fixes the orphaned reply issue you can see in the screenshot. Essentially if one Note in the chain is missing for some reason we're currently creating a new topic. We need to discard by default in this scenario. The "better" version is that we traverse the reply chain N number of times to see if we can find an existing post.

<img width="1205" alt="Screenshot at May 03 09-06-58" src="https://github.com/discourse/discourse-activity-pub/assets/5931623/98ae0638-23de-4ebc-8374-7f0032c97200">
