### PR TITLE
HOTFIX: Fix error when a topic has no category or tag

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -228,7 +228,7 @@ after_initialize do
   Topic.include DiscourseActivityPub::AP::ModelHelpers
 
   add_to_class(:topic, :activity_pub_taxonomies) do
-    [*tags, category].select { |t| t.activity_pub_actor.present? }
+    [*tags, category].select { |t| t&.activity_pub_actor.present? }
   end
   add_to_class(:topic, :activity_pub_taxonomy) { activity_pub_taxonomies.first }
   add_to_class(:topic, :activity_pub_enabled) do


### PR DESCRIPTION
This would fail on PMs with the following:

```
NoMethodError (undefined method `activity_pub_actor' for nil:NilClass)
```

Will follow up with a test later.