### PR TITLE
Add context resolver

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -71,7 +71,6 @@ en:
         object_not_ready: "Object is not ready"
         activity_already_processed: "Activity has already been processed"
         activity_not_supported: "Activity is not supported for actor and object"
-        activity_not_valid: "Activity is not valid"
         invalid_create_actor: "Actor cannot create posts"
         cannot_reply_to_deleted_post: "Cannot create an object inReplyTo a deleted Post"
         undo_actor_must_match_object_actor: "Undo Actor must match Object Actor"
@@ -84,6 +83,7 @@ en:
         only_followed_actors_create_new_topics: "Only followed actors can create new topics."
         actor_already_following: "Actor is already following that object"
         invalid_collection_item: "Invalid item"
+        cannot_resolve_context: "Cannot resolve object context"
       error:
         failed_to_create_user: "Failed to create user for %{actor_id}"
         failed_to_create_post: "Failed to create post for %{object_id}"

--- a/lib/discourse_activity_pub/ap/activity/compose.rb
+++ b/lib/discourse_activity_pub/ap/activity/compose.rb
@@ -9,7 +9,9 @@ module DiscourseActivityPub
         end
 
         def validate_activity
-          return false unless activity_host_matches_object_host?
+          unless activity_host_matches_object_host?
+            raise DiscourseActivityPub::AP::Handlers::Warning
+          end
           super
         end
       end

--- a/lib/discourse_activity_pub/ap/handlers.rb
+++ b/lib/discourse_activity_pub/ap/handlers.rb
@@ -3,9 +3,11 @@
 module DiscourseActivityPub
   module AP
     module Handlers
-      class Error < StandardError
-        class Validate < Error
+      class Warning < StandardError
+        class Validate < Warning
         end
+      end
+      class Error < StandardError
         class Perform < Error
         end
         class Store < Error
@@ -73,7 +75,8 @@ module DiscourseActivityPub
               begin
                 proc.call(activity, { parent: parent })
                 true
-              rescue DiscourseActivityPub::AP::Handlers::Error => error
+              rescue DiscourseActivityPub::AP::Handlers::Warning,
+                     DiscourseActivityPub::AP::Handlers::Error => error
                 activity.add_error(error)
                 raise_errors ? raise : false
               end

--- a/lib/discourse_activity_pub/ap/object.rb
+++ b/lib/discourse_activity_pub/ap/object.rb
@@ -22,7 +22,8 @@ module DiscourseActivityPub
       end
 
       def id
-        stored&.ap_id
+        return stored.ap_id if stored
+        json["id"] if json
       end
 
       def type
@@ -181,7 +182,7 @@ module DiscourseActivityPub
         object
       end
 
-      def self.resolve(raw_object)
+      def self.resolve(raw_object, resolve_attribution: true)
         object_id = DiscourseActivityPub::JsonLd.resolve_id(raw_object)
         return process_failed(raw_object, "cant_resolve_object") unless object_id.present?
 
@@ -205,7 +206,7 @@ module DiscourseActivityPub
           return process_failed(resolved_object["id"], "object_not_supported")
         end
 
-        if object.json[:attributedTo]
+        if resolve_attribution && object.json[:attributedTo]
           attributed_to = Actor.resolve_and_store(object.json[:attributedTo])
           object.attributed_to = attributed_to if attributed_to.present?
         end

--- a/lib/discourse_activity_pub/ap/object/article.rb
+++ b/lib/discourse_activity_pub/ap/object/article.rb
@@ -12,7 +12,8 @@ module DiscourseActivityPub
         end
 
         def in_reply_to
-          stored&.reply_to_id
+          return stored.reply_to_id if stored
+          json["inReplyTo"] if json
         end
 
         def can_belong_to

--- a/lib/discourse_activity_pub/ap/object/note.rb
+++ b/lib/discourse_activity_pub/ap/object/note.rb
@@ -12,7 +12,8 @@ module DiscourseActivityPub
         end
 
         def in_reply_to
-          stored&.reply_to_id
+          return stored.reply_to_id if stored
+          json["inReplyTo"] if json
         end
 
         def can_belong_to

--- a/lib/discourse_activity_pub/context_resolver.rb
+++ b/lib/discourse_activity_pub/context_resolver.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module DiscourseActivityPub
+  class ContextResolver
+    include HasErrors
+
+    REPLY_DEPTH_LIMIT = 3
+
+    attr_reader :object
+    attr_accessor :local_object, :remote_objects
+
+    def initialize(object)
+      @object = object
+    end
+
+    def perform
+      return unless resolve_context?
+
+      traverse_replies
+
+      if local_object
+        resolve_and_store_remote_objects
+      else
+        add_error(I18n.t("discourse_activity_pub.process.warning.cannot_resolve_context"))
+      end
+    end
+
+    def success?
+      errors.blank?
+    end
+
+    def self.perform(object)
+      new(object).perform
+    end
+
+    protected
+
+    def resolve_context?
+      # Resolve the context of unhandled replies without a post in reply to
+      object.model_id.blank? && object.reply_to_id.present? && object.in_reply_to_post.blank?
+    end
+
+    def traverse_replies
+      reply_depth = 1
+      reply_to_object = object.ap
+      @local_object = nil
+      @remote_objects = []
+
+      while local_object.nil? && reply_to_object&.in_reply_to.present? &&
+              reply_depth <= REPLY_DEPTH_LIMIT
+        reply_to_object =
+          DiscourseActivityPub::AP::Object.resolve(
+            reply_to_object.in_reply_to,
+            resolve_attribution: false,
+          )
+        break unless reply_to_object.present?
+
+        object = DiscourseActivityPubObject.find_by(ap_id: reply_to_object.id)
+        if object
+          # We only resolve a context in a full_topic topic
+          if object.model&.topic&.activity_pub_full_topic_enabled
+            @local_object = object
+          else
+            reply_to_object = nil
+          end
+        else
+          remote_objects << reply_to_object
+        end
+
+        reply_depth += 1
+      end
+    end
+
+    def resolve_and_store_remote_objects
+      # If anything fails everything has to be rolled back
+      ActiveRecord::Base.transaction do
+        remote_objects.each do |remote_object|
+          new_local_object =
+            DiscourseActivityPub::AP::Object.resolve_and_store(
+              remote_object.json,
+              DiscourseActivityPub::AP::Activity.factory(
+                { type: DiscourseActivityPub::AP::Activity::Create.type },
+              ),
+            )
+          rollback_remote_store unless new_local_object&.stored.present?
+
+          user =
+            DiscourseActivityPub::ActorHandler.update_or_create_user(
+              new_local_object.stored.attributed_to,
+            )
+          rollback_remote_store unless user.present?
+
+          post =
+            DiscourseActivityPub::PostHandler.create(
+              user,
+              new_local_object.stored,
+              topic_id: local_object.model.topic_id,
+            )
+          rollback_remote_store unless post.present?
+        end
+      end
+    end
+
+    def rollback_remote_store
+      add_error(I18n.t("discourse_activity_pub.process.warning.cannot_resolve_context"))
+      raise ActiveRecord::Rollback
+    end
+  end
+end

--- a/lib/discourse_activity_pub/context_resolver.rb
+++ b/lib/discourse_activity_pub/context_resolver.rb
@@ -53,7 +53,7 @@ module DiscourseActivityPub
             reply_to_object.in_reply_to,
             resolve_attribution: false,
           )
-        break unless reply_to_object.present?
+        break if reply_to_object.blank?
 
         object = DiscourseActivityPubObject.find_by(ap_id: reply_to_object.id)
         if object
@@ -82,13 +82,13 @@ module DiscourseActivityPub
                 { type: DiscourseActivityPub::AP::Activity::Create.type },
               ),
             )
-          rollback_remote_store unless new_local_object&.stored.present?
+          rollback_remote_store if new_local_object&.stored.blank?
 
           user =
             DiscourseActivityPub::ActorHandler.update_or_create_user(
               new_local_object.stored.attributed_to,
             )
-          rollback_remote_store unless user.present?
+          rollback_remote_store if user.blank?
 
           post =
             DiscourseActivityPub::PostHandler.create(
@@ -96,7 +96,7 @@ module DiscourseActivityPub
               new_local_object.stored,
               topic_id: local_object.model.topic_id,
             )
-          rollback_remote_store unless post.present?
+          rollback_remote_store if post.blank?
         end
       end
     end

--- a/lib/discourse_activity_pub/post_handler.rb
+++ b/lib/discourse_activity_pub/post_handler.rb
@@ -16,7 +16,7 @@ module DiscourseActivityPub
       import_mode: false
     )
       if !user || !object || object.model_id ||
-           (!object.in_reply_to_post && !category_id && !tag_id)
+           (!object.in_reply_to_post && !category_id && !tag_id && !topic_id)
         return nil
       end
 
@@ -28,7 +28,7 @@ module DiscourseActivityPub
 
       new_topic = !object.reply_to_id && !topic_id && (category || tag)
       reply_to = object.in_reply_to_post
-      return nil if !import_mode && !new_topic && !reply_to
+      return nil if !import_mode && !new_topic && !reply_to && !topic_id
 
       params = {
         raw: object.content,
@@ -86,7 +86,7 @@ module DiscourseActivityPub
           object.update(
             model_type: "Post",
             model_id: post.id,
-            collection_id: post.topic.activity_pub_object.id,
+            collection_id: post.topic.activity_pub_object&.id,
           )
         end
       end
@@ -116,17 +116,17 @@ module DiscourseActivityPub
       post = activity.object.stored.model
 
       unless post
-        raise DiscourseActivityPub::AP::Handlers::Error::Validate,
+        raise DiscourseActivityPub::AP::Handlers::Warning::Validate,
               I18n.t("discourse_activity_pub.process.warning.cant_find_post")
       end
 
       if post.trashed?
-        raise DiscourseActivityPub::AP::Handlers::Error::Validate,
+        raise DiscourseActivityPub::AP::Handlers::Warning::Validate,
               I18n.t("discourse_activity_pub.process.warning.post_is_deleted")
       end
 
       unless post.activity_pub_full_topic
-        raise DiscourseActivityPub::AP::Handlers::Error::Validate,
+        raise DiscourseActivityPub::AP::Handlers::Warning::Validate,
               I18n.t("discourse_activity_pub.process.warning.full_topic_not_enabled")
       end
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -39,6 +39,7 @@ after_initialize do
   require_relative "lib/discourse_activity_pub/webfinger/handle"
   require_relative "lib/discourse_activity_pub/activity_forwarder"
   require_relative "lib/discourse_activity_pub/logger"
+  require_relative "lib/discourse_activity_pub/context_resolver"
   require_relative "lib/discourse_activity_pub/ap"
   require_relative "lib/discourse_activity_pub/ap/handlers"
   require_relative "lib/discourse_activity_pub/ap/object"
@@ -721,21 +722,28 @@ after_initialize do
 
   DiscourseActivityPub::AP::Activity.add_handler(:activity, :validate) do |activity|
     if DiscourseActivityPubActivity.exists?(ap_id: activity.json[:id])
-      raise DiscourseActivityPub::AP::Handlers::Error::Validate,
+      raise DiscourseActivityPub::AP::Handlers::Warning::Validate,
             I18n.t("discourse_activity_pub.process.warning.activity_already_processed")
     end
   end
 
   DiscourseActivityPub::AP::Activity.add_handler(:create, :validate) do |activity|
-    reply_to_post = activity.object.stored.in_reply_to_post
+    context_resolver = DiscourseActivityPub::ContextResolver.new(activity.object.stored)
+    context_resolver.perform
+    unless context_resolver.success?
+      raise DiscourseActivityPub::AP::Handlers::Warning::Validate,
+            context_resolver.errors.full_messages.join(", ")
+    end
+
+    reply_to_post = activity.object.stored.reload.in_reply_to_post
 
     if reply_to_post
       if reply_to_post.trashed?
-        raise DiscourseActivityPub::AP::Handlers::Error::Validate,
+        raise DiscourseActivityPub::AP::Handlers::Warning::Validate,
               I18n.t("discourse_activity_pub.process.warning.cannot_reply_to_deleted_post")
       end
       unless reply_to_post.activity_pub_full_topic
-        raise DiscourseActivityPub::AP::Handlers::Error::Validate,
+        raise DiscourseActivityPub::AP::Handlers::Warning::Validate,
               I18n.t("discourse_activity_pub.process.warning.full_topic_not_enabled")
       end
     else
@@ -753,7 +761,7 @@ after_initialize do
       end
 
       if delivered_to_actors.blank?
-        raise DiscourseActivityPub::AP::Handlers::Error::Validate,
+        raise DiscourseActivityPub::AP::Handlers::Warning::Validate,
               I18n.t("discourse_activity_pub.process.warning.actor_does_not_accept_new_topics")
       end
 
@@ -761,7 +769,7 @@ after_initialize do
                actor.following?(activity.actor.stored) ||
                  actor.following?(activity.parent&.actor&.stored)
              }
-        raise DiscourseActivityPub::AP::Handlers::Error::Validate,
+        raise DiscourseActivityPub::AP::Handlers::Warning::Validate,
               I18n.t(
                 "discourse_activity_pub.process.warning.only_followed_actors_create_new_topics",
               )
@@ -770,7 +778,7 @@ after_initialize do
       delivered_to_model = delivered_to_actors.first.model
 
       if !delivered_to_model.activity_pub_ready?
-        raise DiscourseActivityPub::AP::Handlers::Error::Validate,
+        raise DiscourseActivityPub::AP::Handlers::Warning::Validate,
               I18n.t("discourse_activity_pub.process.warning.object_not_ready")
       end
 
@@ -795,7 +803,7 @@ after_initialize do
 
   DiscourseActivityPub::AP::Activity.add_handler(:announce, :validate) do |activity|
     unless DiscourseActivityPub::JsonLd.publicly_addressed?(activity.json)
-      raise DiscourseActivityPub::AP::Handlers::Error::Validate,
+      raise DiscourseActivityPub::AP::Handlers::Warning::Validate,
             I18n.t("discourse_activity_pub.process.warning.announce_not_publicly_addressed")
     end
 

--- a/spec/lib/discourse_activity_pub/ap/activity/announce_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/announce_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Announce do
             end
 
             before do
-              stub_stored_request(object_json)
-              stub_stored_request(note_actor)
+              stub_object_request(object_json)
+              stub_object_request(note_actor)
               perform_process(announce_json, category.activity_pub_actor.ap_id)
             end
 

--- a/spec/lib/discourse_activity_pub/ap/activity/follow_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/follow_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Follow do
             json = build_activity_json(object: category.activity_pub_actor)
             json["actor"]["id"] = existing_activity.actor.ap_id
             json["object"] = existing_activity.object.ap_id
-            stub_stored_request(existing_activity.object)
+            stub_object_request(existing_activity.object)
             perform_process(json)
             @new_activity = DiscourseActivityPubActivity.find_by(ap_id: json["id"])
           end

--- a/spec/lib/discourse_activity_pub/ap/activity/like_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/like_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Like do
         end
 
         before do
-          stub_stored_request(note)
-          stub_stored_request(note.attributed_to)
+          stub_object_request(note)
+          stub_object_request(note.attributed_to)
           perform_process(activity_json)
           @user =
             User.joins(:activity_pub_actor).where(activity_pub_actor: { ap_id: person.ap_id }).first
@@ -68,8 +68,8 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Like do
         end
 
         before do
-          stub_stored_request(note)
-          stub_stored_request(note.attributed_to)
+          stub_object_request(note)
+          stub_object_request(note.attributed_to)
           perform_process(activity_json)
           @user =
             User.joins(:activity_pub_actor).where(activity_pub_actor: { ap_id: person.ap_id }).first

--- a/spec/lib/discourse_activity_pub/ap/activity_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
 
   describe "#process" do
     before do
-      stub_stored_request(note.attributed_to)
+      stub_object_request(note.attributed_to)
       toggle_activity_pub(category, publication_type: "full_topic")
       topic.create_activity_pub_collection!
     end
@@ -49,8 +49,8 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
         it "logs the right warning" do
           perform_process(json, activity_type)
           perform_process(json, activity_type)
-          expect(@fake_logger.warnings.first).to eq(
-            build_process_warning("activity_already_processed", json["id"]),
+          expect(@fake_logger.warnings.first).to match(
+            I18n.t("discourse_activity_pub.process.warning.activity_already_processed"),
           )
         end
       end
@@ -94,7 +94,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity do
     end
 
     context "with a valid activity" do
-      before { stub_stored_request(note.attributed_to) }
+      before { stub_object_request(note.attributed_to) }
 
       context "without activity pub enabled" do
         it "returns false" do

--- a/spec/lib/discourse_activity_pub/context_resolver_spec.rb
+++ b/spec/lib/discourse_activity_pub/context_resolver_spec.rb
@@ -1,0 +1,281 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseActivityPub::ContextResolver do
+  describe "#perform" do
+    context "with an object not in reply to" do
+      let!(:object) { Fabricate(:discourse_activity_pub_object_note, model: nil) }
+
+      it "does not make requests" do
+        expect_no_request
+        described_class.perform(object)
+      end
+
+      it "succeeds" do
+        resolver = described_class.new(object)
+        resolver.perform
+        expect(resolver.success?).to be_truthy
+      end
+    end
+
+    context "with a local object within the reply depth limit" do
+      let!(:local_object) { Fabricate(:discourse_activity_pub_object_note) }
+      let!(:reply_to_2_actor_json) { build_actor_json }
+      let!(:reply_to_2_json) do
+        build_object_json(
+          in_reply_to: local_object.ap_id,
+          attributed_to: reply_to_2_actor_json[:id],
+        )
+      end
+      let!(:reply_to_1_actor_json) { build_actor_json }
+      let!(:reply_to_1_json) do
+        build_object_json(
+          in_reply_to: reply_to_2_json[:id],
+          attributed_to: reply_to_1_actor_json[:id],
+        )
+      end
+      let!(:object) do
+        Fabricate(
+          :discourse_activity_pub_object_note,
+          reply_to_id: reply_to_1_json[:id],
+          model: nil,
+        )
+      end
+
+      context "when the remote objects successfully resolve" do
+        before do
+          stub_object_request(reply_to_1_actor_json)
+          stub_object_request(reply_to_1_json)
+          stub_object_request(reply_to_2_actor_json)
+          stub_object_request(reply_to_2_json)
+        end
+
+        context "when the local object is in a full_topic topic" do
+          let!(:category) { Fabricate(:category) }
+          let!(:topic) { Fabricate(:topic, category: category) }
+          let!(:post) { Fabricate(:post, topic: topic) }
+
+          before do
+            local_object.update(model_id: post.id, model_type: "Post")
+            toggle_activity_pub(category, publication_type: "full_topic")
+            topic.create_activity_pub_collection!
+          end
+
+          it "resolves and stores the remote objects" do
+            described_class.perform(object)
+            expect(
+              DiscourseActivityPubActor.where(ap_id: reply_to_1_actor_json[:id]).exists?,
+            ).to be_truthy
+            expect(
+              DiscourseActivityPubActor.where(ap_id: reply_to_2_actor_json[:id]).exists?,
+            ).to be_truthy
+            expect(
+              DiscourseActivityPubObject.where(
+                ap_id: reply_to_1_json[:id],
+                reply_to_id: reply_to_2_json[:id],
+              ).exists?,
+            ).to be_truthy
+            expect(
+              DiscourseActivityPubObject.where(
+                ap_id: reply_to_2_json[:id],
+                reply_to_id: local_object.ap_id,
+              ).exists?,
+            ).to be_truthy
+          end
+
+          it "creates users and posts for the actors and objects in the reply chain" do
+            described_class.perform(object)
+            user1 = DiscourseActivityPubActor.find_by(ap_id: reply_to_1_actor_json[:id])&.model
+            user2 = DiscourseActivityPubActor.find_by(ap_id: reply_to_2_actor_json[:id])&.model
+            expect(user1.present?).to be_truthy
+            expect(user2.present?).to be_truthy
+            expect(
+              Post.where(raw: reply_to_1_json[:content], user_id: user1.id).exists?,
+            ).to be_truthy
+            expect(
+              Post.where(raw: reply_to_2_json[:content], user_id: user2.id).exists?,
+            ).to be_truthy
+          end
+
+          it "succeeds" do
+            resolver = described_class.new(object)
+            resolver.perform
+            expect(resolver.success?).to be_truthy
+          end
+        end
+
+        context "when the local object is not in a full_topic topic" do
+          let!(:category) { Fabricate(:category) }
+          let!(:topic) { Fabricate(:topic, category: category) }
+          let!(:post) { Fabricate(:post, topic: topic) }
+
+          before do
+            local_object.update(model_id: post.id, model_type: "Post")
+            toggle_activity_pub(category, publication_type: "first_post")
+          end
+
+          it "does not store the remote objects" do
+            described_class.perform(object)
+            expect(
+              DiscourseActivityPubActor.where(ap_id: reply_to_1_actor_json[:id]).exists?,
+            ).to be_falsey
+            expect(
+              DiscourseActivityPubActor.where(ap_id: reply_to_2_actor_json[:id]).exists?,
+            ).to be_falsey
+            expect(
+              DiscourseActivityPubObject.where(ap_id: reply_to_1_json[:id]).exists?,
+            ).to be_falsey
+            expect(
+              DiscourseActivityPubObject.where(ap_id: reply_to_2_json[:id]).exists?,
+            ).to be_falsey
+          end
+
+          it "does not create users and posts for the actors and objects in the reply chain" do
+            described_class.perform(object)
+            user1 = DiscourseActivityPubActor.find_by(ap_id: reply_to_1_actor_json[:id])&.model
+            user2 = DiscourseActivityPubActor.find_by(ap_id: reply_to_2_actor_json[:id])&.model
+            expect(user1.present?).to be_falsey
+            expect(user2.present?).to be_falsey
+            expect(Post.where(raw: reply_to_1_json[:content]).exists?).to be_falsey
+            expect(Post.where(raw: reply_to_2_json[:content]).exists?).to be_falsey
+          end
+
+          it "does not succeed" do
+            resolver = described_class.new(object)
+            resolver.perform
+            expect(resolver.success?).to be_falsey
+          end
+        end
+      end
+
+      context "when some remote objects don't successfully resolve" do
+        before do
+          stub_object_request(reply_to_1_actor_json, status: 404, body: {}.to_json)
+          stub_object_request(reply_to_1_json)
+          stub_object_request(reply_to_2_actor_json)
+          stub_object_request(reply_to_2_json)
+        end
+
+        context "when the local object is in a full_topic topic" do
+          let!(:category) { Fabricate(:category) }
+          let!(:topic) { Fabricate(:topic, category: category) }
+          let!(:post) { Fabricate(:post, topic: topic) }
+
+          before do
+            local_object.update(model_id: post.id, model_type: "Post")
+            toggle_activity_pub(category, publication_type: "full_topic")
+            topic.create_activity_pub_collection!
+          end
+
+          it "does not store the remote objects" do
+            described_class.perform(object)
+            expect(
+              DiscourseActivityPubActor.where(ap_id: reply_to_1_actor_json[:id]).exists?,
+            ).to be_falsey
+            expect(
+              DiscourseActivityPubActor.where(ap_id: reply_to_2_actor_json[:id]).exists?,
+            ).to be_falsey
+            expect(
+              DiscourseActivityPubObject.where(ap_id: reply_to_1_json[:id]).exists?,
+            ).to be_falsey
+            expect(
+              DiscourseActivityPubObject.where(ap_id: reply_to_2_json[:id]).exists?,
+            ).to be_falsey
+          end
+
+          it "does not create users and posts for the actors and objects in the reply chain" do
+            described_class.perform(object)
+            user1 = DiscourseActivityPubActor.find_by(ap_id: reply_to_1_actor_json[:id])&.model
+            user2 = DiscourseActivityPubActor.find_by(ap_id: reply_to_2_actor_json[:id])&.model
+            expect(user1.present?).to be_falsey
+            expect(user2.present?).to be_falsey
+            expect(Post.where(raw: reply_to_1_json[:content]).exists?).to be_falsey
+            expect(Post.where(raw: reply_to_2_json[:content]).exists?).to be_falsey
+          end
+
+          it "does not succeed" do
+            resolver = described_class.new(object)
+            resolver.perform
+            expect(resolver.success?).to be_falsey
+          end
+        end
+      end
+    end
+
+    context "with a local object not within the reply depth limit" do
+      let!(:local_object) { Fabricate(:discourse_activity_pub_object_note) }
+
+      let!(:reply_to_4_actor_json) { build_actor_json }
+      let!(:reply_to_4_json) do
+        build_object_json(
+          in_reply_to: local_object.ap_id,
+          attributed_to: reply_to_3_actor_json[:id],
+        )
+      end
+      let!(:reply_to_3_actor_json) { build_actor_json }
+      let!(:reply_to_3_json) do
+        build_object_json(
+          in_reply_to: reply_to_4_json[:id],
+          attributed_to: reply_to_3_actor_json[:id],
+        )
+      end
+      let!(:reply_to_2_actor_json) { build_actor_json }
+      let!(:reply_to_2_json) do
+        build_object_json(
+          in_reply_to: reply_to_3_json[:id],
+          attributed_to: reply_to_2_actor_json[:id],
+        )
+      end
+      let!(:reply_to_1_actor_json) { build_actor_json }
+      let!(:reply_to_1_json) do
+        build_object_json(
+          in_reply_to: reply_to_2_json[:id],
+          attributed_to: reply_to_1_actor_json[:id],
+        )
+      end
+      let!(:object) do
+        Fabricate(
+          :discourse_activity_pub_object_note,
+          reply_to_id: reply_to_1_json[:id],
+          model: nil,
+        )
+      end
+
+      before do
+        stub_object_request(reply_to_1_actor_json)
+        stub_object_request(reply_to_1_json)
+        stub_object_request(reply_to_2_actor_json)
+        stub_object_request(reply_to_2_json)
+        stub_object_request(reply_to_3_actor_json)
+        stub_object_request(reply_to_3_json)
+        stub_object_request(reply_to_4_actor_json)
+        stub_object_request(reply_to_4_json)
+      end
+
+      it "does not store the remote objects" do
+        described_class.perform(object)
+        expect(
+          DiscourseActivityPubActor.where(ap_id: reply_to_1_actor_json[:id]).exists?,
+        ).to be_falsey
+        expect(
+          DiscourseActivityPubActor.where(ap_id: reply_to_2_actor_json[:id]).exists?,
+        ).to be_falsey
+        expect(
+          DiscourseActivityPubActor.where(ap_id: reply_to_3_actor_json[:id]).exists?,
+        ).to be_falsey
+        expect(
+          DiscourseActivityPubActor.where(ap_id: reply_to_4_actor_json[:id]).exists?,
+        ).to be_falsey
+        expect(DiscourseActivityPubObject.where(ap_id: reply_to_1_json[:id]).exists?).to be_falsey
+        expect(DiscourseActivityPubObject.where(ap_id: reply_to_2_json[:id]).exists?).to be_falsey
+        expect(DiscourseActivityPubObject.where(ap_id: reply_to_3_json[:id]).exists?).to be_falsey
+        expect(DiscourseActivityPubObject.where(ap_id: reply_to_4_json[:id]).exists?).to be_falsey
+      end
+
+      it "does not succeed" do
+        resolver = described_class.new(object)
+        resolver.perform
+        expect(resolver.success?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -123,7 +123,7 @@ def build_actor_json(
 )
   _json = {
     "@context": "https://www.w3.org/ns/activitystreams",
-    id: "https://external.com/u/#{preferredUsername}",
+    id: "https://external.com/u/#{preferredUsername}/#{SecureRandom.hex(8)}",
     name: name,
     preferredUsername: preferredUsername,
     type: type,
@@ -142,7 +142,7 @@ def build_object_json(
   id: nil,
   type: "Note",
   name: nil,
-  content: "My cool note",
+  content: "My cool note #{SecureRandom.hex(8)}",
   in_reply_to: nil,
   published: nil,
   url: nil,
@@ -297,15 +297,15 @@ def expect_no_delivery
   DiscourseActivityPub::DeliveryHandler.expects(:perform).never
 end
 
-def stub_stored_request(object)
+def stub_object_request(object, body: nil, status: 200)
   object_id = object.respond_to?(:ap_id) ? object.ap_id : object[:id]
   object_json = object.respond_to?(:ap) ? object.ap.json : object
   stub_request(:get, object_id).to_return(
-    body: object_json.to_json,
+    body: body || object_json.to_json,
     headers: {
       "Content-Type" => "application/json",
     },
-    status: 200,
+    status: status,
   )
 end
 


### PR DESCRIPTION
@pmusaraj This resolves the issue described here: https://socialhub.activitypub.rocks/t/traversing-the-reply-chain-when-working-with-topics/4187

In short, if the plugin receives a Note inReplyTo a remote Note, we will resolve up to 3 replies to see if there is a Note in the chain in an existing topic, in which case we'll convert the intervening replies, and the new reply, into posts in the existing topic.