### PR TITLE
Fix local suspension of remote actor user

### DIFF
--- a/app/models/concerns/discourse_activity_pub/ap/model_callbacks.rb
+++ b/app/models/concerns/discourse_activity_pub/ap/model_callbacks.rb
@@ -25,6 +25,8 @@ module DiscourseActivityPub
           DiscourseActivityPub::AP::Object.from_type(target_activity_type) if target_activity_type
         return unless valid_activity_pub_activity?
 
+        return false unless ensure_activity_pub_actor
+
         @performing_activity_object = get_performing_activity_object
         return unless performing_activity_object
 
@@ -50,9 +52,6 @@ module DiscourseActivityPub
 
         # We don't permit updates if object has been deleted.
         return false if self.activity_pub_deleted? && performing_activity.update?
-
-        # Can't have an activity without an actor.
-        return false unless self.activity_pub_actor
 
         true
       end
@@ -209,6 +208,11 @@ module DiscourseActivityPub
         else
           nil
         end
+      end
+
+      def ensure_activity_pub_actor
+        return self.activity_pub_actor.present? if self.activity_pub_first_post
+        DiscourseActivityPub::ActorHandler.update_or_create_actor(user)
       end
     end
   end

--- a/extensions/discourse_activity_pub_user_extension.rb
+++ b/extensions/discourse_activity_pub_user_extension.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-module DiscourseActivityPubUserExtension
-  def skip_email_validation
-    self.activity_pub_actor&.remote? || super
-  end
-end

--- a/extensions/discourse_activity_pub_user_extension.rb
+++ b/extensions/discourse_activity_pub_user_extension.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module DiscourseActivityPubUserExtension
+  def skip_email_validation
+    self.activity_pub_actor&.remote? || super
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -127,6 +127,7 @@ after_initialize do
   require_relative "app/serializers/discourse_activity_pub/admin/actor_serializer"
   require_relative "config/routes"
   require_relative "extensions/discourse_activity_pub_guardian_extension"
+  require_relative "extensions/discourse_activity_pub_user_extension"
 
   # DiscourseActivityPub.enabled is the single source of truth for whether
   # ActivityPub is enabled on the site level
@@ -567,6 +568,7 @@ after_initialize do
 
   # TODO: This should just be part of discourse/discourse.
   User.skip_callback :create, :after, :create_email_token, if: -> { self.skip_email_validation }
+  User.prepend DiscourseActivityPubUserExtension
 
   add_to_class(:user, :activity_pub_enabled) { DiscourseActivityPub.enabled }
   add_to_class(:user, :activity_pub_ready?) { true }

--- a/spec/lib/discourse_activity_pub/bulk/publish_spec.rb
+++ b/spec/lib/discourse_activity_pub/bulk/publish_spec.rb
@@ -57,10 +57,10 @@ RSpec.describe DiscourseActivityPub::Bulk::Publish do
 
         it "creates the right actors" do
           described_class.perform(actor_id: actor.id)
-          expect(post1.user.activity_pub_actor.name).to eq(post1.user.name)
-          expect(post2.user.activity_pub_actor.name).to eq(post2.user.name)
-          expect(post3.user.activity_pub_actor.name).to eq(post3.user.name)
-          expect(post4.user.activity_pub_actor.name).to eq(post4.user.name)
+          expect(post1.reload.user.activity_pub_actor.name).to eq(post1.user.name)
+          expect(post2.reload.user.activity_pub_actor.name).to eq(post2.user.name)
+          expect(post3.reload.user.activity_pub_actor.name).to eq(post3.user.name)
+          expect(post4.reload.user.activity_pub_actor.name).to eq(post4.user.name)
           expect(post1.user.activity_pub_actor.username).to eq(post1.user.username)
           expect(post2.user.activity_pub_actor.username).to eq(post2.user.username)
           expect(post3.user.activity_pub_actor.username).to eq(post3.user.username)
@@ -69,10 +69,10 @@ RSpec.describe DiscourseActivityPub::Bulk::Publish do
 
         it "creates the right post objects" do
           described_class.perform(actor_id: actor.id)
-          expect(post1.activity_pub_object.content).to eq(post1.cooked)
-          expect(post2.activity_pub_object.content).to eq(post2.cooked)
-          expect(post3.activity_pub_object.content).to eq(post3.cooked)
-          expect(post4.activity_pub_object.content).to eq(post4.cooked)
+          expect(post1.reload.activity_pub_object.content).to eq(post1.cooked)
+          expect(post2.reload.activity_pub_object.content).to eq(post2.cooked)
+          expect(post3.reload.activity_pub_object.content).to eq(post3.cooked)
+          expect(post4.reload.activity_pub_object.content).to eq(post4.cooked)
           expect(post2.activity_pub_object.reply_to_id).to eq(post1.activity_pub_object.ap_id)
           expect(post4.activity_pub_object.reply_to_id).to eq(post3.activity_pub_object.ap_id)
           expect(post1.activity_pub_object.collection_id).to eq(post1.topic.activity_pub_object.id)
@@ -119,10 +119,10 @@ RSpec.describe DiscourseActivityPub::Bulk::Publish do
 
         it "creates the right activities" do
           described_class.perform(actor_id: actor.id)
-          expect(post1.activity_pub_object.activities.first.ap_type).to eq("Create")
-          expect(post2.activity_pub_object.activities.first.ap_type).to eq("Create")
-          expect(post3.activity_pub_object.activities.first.ap_type).to eq("Create")
-          expect(post4.activity_pub_object.activities.first.ap_type).to eq("Create")
+          expect(post1.reload.activity_pub_object.activities.first.ap_type).to eq("Create")
+          expect(post2.reload.activity_pub_object.activities.first.ap_type).to eq("Create")
+          expect(post3.reload.activity_pub_object.activities.first.ap_type).to eq("Create")
+          expect(post4.reload.activity_pub_object.activities.first.ap_type).to eq("Create")
           expect(post1.activity_pub_object.activities.first.actor.id).to eq(
             post1.user.activity_pub_actor.id,
           )
@@ -289,16 +289,16 @@ RSpec.describe DiscourseActivityPub::Bulk::Publish do
 
         it "creates the right actors" do
           described_class.perform(actor_id: actor.id)
-          expect(post2.user.activity_pub_actor.name).to eq(post2.user.name)
-          expect(post3.user.activity_pub_actor.name).to eq(post3.user.name)
+          expect(post2.reload.user.activity_pub_actor.name).to eq(post2.user.name)
+          expect(post3.reload.user.activity_pub_actor.name).to eq(post3.user.name)
           expect(post2.user.activity_pub_actor.username).to eq(post2.user.username)
           expect(post3.user.activity_pub_actor.username).to eq(post3.user.username)
         end
 
         it "creates the right post objects" do
           described_class.perform(actor_id: actor.id)
-          expect(post2.activity_pub_object.content).to eq(post2.cooked)
-          expect(post3.activity_pub_object.content).to eq(post3.cooked)
+          expect(post2.reload.activity_pub_object.content).to eq(post2.cooked)
+          expect(post3.reload.activity_pub_object.content).to eq(post3.cooked)
           expect(post2.activity_pub_object.reply_to_id).to eq(post1.activity_pub_object.ap_id)
           expect(post2.activity_pub_object.collection_id).to eq(post2.topic.activity_pub_object.id)
           expect(post3.activity_pub_object.collection_id).to eq(post3.topic.activity_pub_object.id)
@@ -324,8 +324,8 @@ RSpec.describe DiscourseActivityPub::Bulk::Publish do
 
         it "creates the right activities" do
           described_class.perform(actor_id: actor.id)
-          expect(post2.activity_pub_object.activities.first.ap_type).to eq("Create")
-          expect(post3.activity_pub_object.activities.first.ap_type).to eq("Create")
+          expect(post2.reload.activity_pub_object.activities.first.ap_type).to eq("Create")
+          expect(post3.reload.activity_pub_object.activities.first.ap_type).to eq("Create")
           expect(post2.activity_pub_object.activities.first.actor.id).to eq(
             post2.user.activity_pub_actor.id,
           )
@@ -429,20 +429,20 @@ RSpec.describe DiscourseActivityPub::Bulk::Publish do
 
           it "creates the right actors" do
             described_class.perform(actor_id: actor.id)
-            expect(post3.user.activity_pub_actor.name).to eq(post3.user.name)
+            expect(post3.reload.user.activity_pub_actor.name).to eq(post3.user.name)
             expect(post3.user.activity_pub_actor.username).to eq(post3.user.username)
           end
 
           it "creates and publishes the right post objects" do
             described_class.perform(actor_id: actor.id)
-            expect(post3.activity_pub_object.content).to eq(post3.cooked)
+            expect(post3.reload.activity_pub_object.content).to eq(post3.cooked)
             expect(post3.activity_pub_object.collection_id).to eq(
               post3.topic.activity_pub_object.id,
             )
             expect(post3.activity_pub_object.attributed_to_id).to eq(
               post3.user.activity_pub_actor.ap_id,
             )
-            expect(post2.reload.activity_pub_object.published_at).to be_within_one_second_of(
+            expect(post2.reload.reload.activity_pub_object.published_at).to be_within_one_second_of(
               Time.now,
             )
             expect(post3.activity_pub_object.published_at).to be_within_one_second_of(Time.now)
@@ -458,7 +458,7 @@ RSpec.describe DiscourseActivityPub::Bulk::Publish do
 
           it "creates and publishes the right activities" do
             described_class.perform(actor_id: actor.id)
-            expect(post3.activity_pub_object.activities.first.ap_type).to eq("Create")
+            expect(post3.reload.activity_pub_object.activities.first.ap_type).to eq("Create")
             expect(post3.activity_pub_object.activities.first.actor.id).to eq(
               post3.user.activity_pub_actor.id,
             )
@@ -519,8 +519,8 @@ RSpec.describe DiscourseActivityPub::Bulk::Publish do
 
         it "creates the right actors" do
           described_class.perform(actor_id: actor.id)
-          expect(post1.user.activity_pub_actor.name).to eq(post1.user.name)
-          expect(post3.user.activity_pub_actor.name).to eq(post3.user.name)
+          expect(post1.reload.user.activity_pub_actor.name).to eq(post1.user.name)
+          expect(post3.reload.user.activity_pub_actor.name).to eq(post3.user.name)
           expect(post1.user.activity_pub_actor.username).to eq(post1.user.username)
           expect(post3.user.activity_pub_actor.username).to eq(post3.user.username)
         end
@@ -543,8 +543,8 @@ RSpec.describe DiscourseActivityPub::Bulk::Publish do
 
         it "creates the right activities" do
           described_class.perform(actor_id: actor.id)
-          expect(post1.activity_pub_object.activities.first.ap_type).to eq("Create")
-          expect(post3.activity_pub_object.activities.first.ap_type).to eq("Create")
+          expect(post1.reload.activity_pub_object.activities.first.ap_type).to eq("Create")
+          expect(post3.reload.activity_pub_object.activities.first.ap_type).to eq("Create")
           expect(post1.activity_pub_object.activities.first.actor.id).to eq(
             post1.user.activity_pub_actor.id,
           )

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe PostAction do
           end
 
           context "when the topic has remote contributors" do
-            before { post.activity_pub_actor.update(local: false) }
+            before { post.reload.activity_pub_actor.update(local: false) }
 
             it "sends to the remote contributors for delivery without delay" do
               expect_delivery(
@@ -165,7 +165,7 @@ RSpec.describe PostAction do
           end
 
           context "when the topic has remote contributors" do
-            before { post.activity_pub_actor.update(local: false) }
+            before { post.reload.activity_pub_actor.update(local: false) }
 
             it "sends to the remote contributors for delivery without delay" do
               expect_delivery(

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -700,21 +700,6 @@ RSpec.describe Post do
                   .exists?,
               ).to eq(true)
             end
-
-            it "doesn't create a activity with the acting user's actor" do
-              perform_update
-              expect(
-                staff
-                  .activity_pub_actor
-                  .activities
-                  .where(
-                    object_id: post.activity_pub_object.id,
-                    object_type: "DiscourseActivityPubObject",
-                    ap_type: "Update",
-                  )
-                  .exists?,
-              ).to eq(false)
-            end
           end
         end
 
@@ -1145,6 +1130,7 @@ RSpec.describe Post do
               perform_update
               expect(
                 staff
+                  .reload
                   .activity_pub_actor
                   .activities
                   .where(

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::UsersController do
+  fab!(:admin)
+
+  describe "#suspend" do
+    let!(:actor) { Fabricate(:discourse_activity_pub_actor_person, local: false) }
+
+    before { sign_in(admin) }
+
+    it "suspends a user created from a remote activitypub actor" do
+      user = DiscourseActivityPub::ActorHandler.update_or_create_user(actor)
+
+      put "/admin/users/#{user.id}/suspend.json",
+          params: {
+            suspend_until: 5.hours.from_now,
+            reason: "because I said so",
+          }
+
+      expect(response.status).to eq(200)
+
+      user.reload
+      expect(user).to be_suspended
+      expect(user.suspended_at).to be_present
+      expect(user.suspended_till).to be_present
+      expect(user.suspend_record).to be_present
+
+      log = UserHistory.where(target_user_id: user.id).order("id desc").first
+      expect(log.details).to match(/because I said so/)
+    end
+  end
+end


### PR DESCRIPTION
 - Ensure email_validation is skipped for users created from remote actors

@pmusaraj Another small fix. Context: https://meta.discourse.org/t/activitypub-plugin/266794/211?u=angus