### PR TITLE
DEV: Default to sending objects if the collection has no context

### DIFF
--- a/app/models/discourse_activity_pub_collection.rb
+++ b/app/models/discourse_activity_pub_collection.rb
@@ -88,7 +88,7 @@ class DiscourseActivityPubCollection < ActiveRecord::Base
     when :likes
       @items
     else
-      []
+      objects
     end
   end
 

--- a/app/models/discourse_activity_pub_object.rb
+++ b/app/models/discourse_activity_pub_object.rb
@@ -53,9 +53,9 @@ class DiscourseActivityPubObject < ActiveRecord::Base
          DiscourseActivityPub::AP::Activity::Like.type,
          DiscourseActivityPub::AP::Activity::Undo.type,
          DiscourseActivityPub::AP::Activity::Announce.type
-      !!model && !model.trashed?
+      !model_trashed?
     when DiscourseActivityPub::AP::Activity::Delete.type
-      !model || model.trashed?
+      model_trashed?
     else
       false
     end
@@ -67,6 +67,14 @@ class DiscourseActivityPubObject < ActiveRecord::Base
 
   def public?
     !private?
+  end
+
+  def publish?
+    !model_trashed?
+  end
+
+  def model_trashed?
+    !model || model.trashed?
   end
 
   def post?

--- a/spec/requests/discourse_activity_pub/ap/collections_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/collections_controller_spec.rb
@@ -43,5 +43,25 @@ RSpec.describe DiscourseActivityPub::AP::CollectionsController do
       expect(response.status).to eq(200)
       expect(parsed_body).to eq(collection.ap.json)
     end
+
+    context "when collection is for a topic with posts" do
+      let!(:collection) { Fabricate(:discourse_activity_pub_ordered_collection) }
+      let!(:post1) { Fabricate(:post, topic: collection.model) }
+      let!(:post2) { Fabricate(:post, topic: collection.model) }
+      let!(:note1) do
+        Fabricate(:discourse_activity_pub_object_note, model: post1, collection_id: collection.id)
+      end
+      let!(:note2) do
+        Fabricate(:discourse_activity_pub_object_note, model: post2, collection_id: collection.id)
+      end
+
+      it "returns collection json with items" do
+        get_object(collection)
+        expect(response.status).to eq(200)
+        expect(parsed_body["orderedItems"].size).to eq(2)
+        expect(parsed_body["orderedItems"].first["id"]).to eq(note2.ap_id)
+        expect(parsed_body["orderedItems"].last["id"]).to eq(note1.ap_id)
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently no objects are returned when you directly request a collection, outside of the context of the outbox, followers, likes etc. This sends the collection objects by default.