### PR TITLE
PERF: static id for like post action type

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -865,7 +865,12 @@ after_initialize do
     post = activity.object.stored.model
 
     if user && post
-      PostActionCreator.new(user, post, PostActionType.types[:like], reason: :activity_pub).perform
+      PostActionCreator.new(
+        user,
+        post,
+        PostActionType::LIKE_POST_ACTION_ID,
+        reason: :activity_pub,
+      ).perform
     end
   end
 

--- a/spec/lib/discourse_activity_pub/ap/activity/like_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/like_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Like do
             PostAction.exists?(
               post_id: post.id,
               user_id: @user.id,
-              post_action_type_id: PostActionType.types[:like],
+              post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
             ),
           ).to be(true)
         end
@@ -84,7 +84,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Like do
             PostAction.exists?(
               post_id: post.id,
               user_id: @user.id,
-              post_action_type_id: PostActionType.types[:like],
+              post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
             ),
           ).to be(true)
         end

--- a/spec/lib/discourse_activity_pub/ap/activity/undo_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/undo_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Undo do
             :post_action,
             user: user,
             post: post,
-            post_action_type_id: PostActionType.types[:like],
+            post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
           )
         end
         let!(:person) { Fabricate(:discourse_activity_pub_actor_person, model: user) }
@@ -64,7 +64,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Undo do
             PostAction.exists?(
               post_id: post.id,
               user_id: user.id,
-              post_action_type_id: PostActionType.types[:like],
+              post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
             ),
           ).to be(false)
         end

--- a/spec/lib/post_action_destroyer_spec.rb
+++ b/spec/lib/post_action_destroyer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PostActionDestroyer do
       :post_action,
       user: user2,
       post: post,
-      post_action_type_id: PostActionType.types[:like],
+      post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
     )
   end
   let!(:post_action2) do
@@ -24,7 +24,7 @@ RSpec.describe PostActionDestroyer do
       :post_action,
       user: user3,
       post: post,
-      post_action_type_id: PostActionType.types[:like],
+      post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
     )
   end
   let!(:like1) { Fabricate(:discourse_activity_pub_activity_like, actor: actor2, object: note) }

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe PostAction do
       :post_action,
       user: user2,
       post: post,
-      post_action_type_id: PostActionType.types[:like],
+      post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
     )
   end
 


### PR DESCRIPTION
Before flags were in the database, PostActionType.types were stored in memory and getting PostActionType.types[:like] was a very cheap operation.

Now, PostActionType is cached in Redis and we should try to avoid sending too many requests, especially that id for like is always 2.