### PR TITLE
DEV: Fix mismatched column types

### DIFF
--- a/db/migrate/20241014115600_alter_activity_pub_ids_to_bigint.rb
+++ b/db/migrate/20241014115600_alter_activity_pub_ids_to_bigint.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AlterActivityPubIdsToBigint < ActiveRecord::Migration[7.1]
+  def up
+    change_column :discourse_activity_pub_activities, :actor_id, :bigint
+    change_column :discourse_activity_pub_activities, :object_id, :bigint
+    change_column :discourse_activity_pub_objects, :collection_id, :bigint
+    change_column :discourse_activity_pub_follows, :follower_id, :bigint
+    change_column :discourse_activity_pub_follows, :followed_id, :bigint
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
The primary key is usually a bigint column, but the foreign key columns are usually of integer type. This can lead to issues when joining these columns due to mismatched types and different value ranges.