### PR TITLE
FEATURE: Allow actor preferred username changed

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-activity-pub-actor-show.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-activity-pub-actor-show.js
@@ -18,6 +18,7 @@ export default class AdminPluginsActivityPubActorShow extends Controller {
   @tracked enabled = this.actor.enabled;
   @tracked saving = false;
   @tracked saveResponse = null;
+  @tracked actor;
 
   modelTypes = [
     {

--- a/assets/javascripts/discourse/templates/admin-plugins-activity-pub-actor-show.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-activity-pub-actor-show.hbs
@@ -69,6 +69,8 @@
           <div class="activity-pub-actor-setting-description">
             <span>{{i18n
                 "admin.discourse_activity_pub.actor.username_description"
+                min_length=this.siteSettings.min_username_length
+                max_length=this.siteSettings.max_username_length
               }}</span>
           </div>
         </section>

--- a/assets/javascripts/discourse/templates/admin-plugins-activity-pub-actor-show.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-activity-pub-actor-show.hbs
@@ -42,6 +42,7 @@
         @model={{this.actor.model}}
         @modelType={{this.actor.model_type}}
       />
+      <ActivityPubHandle @actor={{this.actor}} />
       <div class="activity-pub-actor-enabled-toggle">
         <DToggleSwitch
           @state={{this.enabled}}
@@ -55,35 +56,22 @@
   <div class="activity-pub-actor-form-container">
     <div class="activity-pub-actor-form">
       {{#if this.showForm}}
-        {{#if this.actor.handle}}
-          <section class="activity-pub-actor-setting activity-pub-handle-field">
-            <label>{{i18n "admin.discourse_activity_pub.actor.handle"}}</label>
-            <ActivityPubHandle @actor={{this.actor}} />
-            <div class="activity-pub-actor-setting-description">
-              {{i18n "admin.discourse_activity_pub.actor.handle_description"}}
-            </div>
-          </section>
-        {{else}}
-          <section class="activity-pub-actor-setting activity-pub-username">
-            <label for="activity-pub-username">{{i18n
-                "admin.discourse_activity_pub.actor.username"
-              }}</label>
-            <div class="activity-pub-username-input">
-              <Input
-                id="activity-pub-username"
-                @value={{this.actor.username}}
-              />
-              <span
-                class="activity-pub-host"
-              >@{{this.site.activity_pub_host}}</span>
-            </div>
-            <div class="activity-pub-actor-setting-notice">
-              <span>{{d-icon "exclamation-triangle"}}{{i18n
-                  "admin.discourse_activity_pub.actor.username_description"
-                }}</span>
-            </div>
-          </section>
-        {{/if}}
+        <section class="activity-pub-actor-setting activity-pub-username">
+          <label for="activity-pub-username">{{i18n
+              "admin.discourse_activity_pub.actor.username"
+            }}</label>
+          <div class="activity-pub-username-input">
+            <Input id="activity-pub-username" @value={{this.actor.username}} />
+            <span
+              class="activity-pub-host"
+            >@{{this.site.activity_pub_host}}</span>
+          </div>
+          <div class="activity-pub-actor-setting-description">
+            <span>{{i18n
+                "admin.discourse_activity_pub.actor.username_description"
+              }}</span>
+          </div>
+        </section>
 
         <section class="activity-pub-actor-setting activity-pub-name">
           <label for="activity-pub-name">{{i18n

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -35,11 +35,9 @@ en:
               title: Login is required by the login required site setting.
               description: Only outgoing follow requests and the attributes of enabled actors are published.
           username: Username
-          username_description: Cannot be changed once saved.
-          handle: Handle
-          handle_description: Used to identify this actor on services using Webfinger (e.g. Mastodon).
+          username_description: 3 or more letters and numbers.
           name: Name
-          name_description: Used as a display name on some services (e.g. Mastodon).
+          name_description: Used as a display name on some services.
           default_visibility: Visibility
           default_visibility_description: All posts will be published via ActivityPub with this visibility.
           post_object_type: Post object type

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -35,7 +35,7 @@ en:
               title: Login is required by the login required site setting.
               description: Only outgoing follow requests and the attributes of enabled actors are published.
           username: Username
-          username_description: 3 or more letters and numbers.
+          username_description: "%{min_length} to %{max_length} letters, numbers, dashes or underscores."
           name: Name
           name_description: Used as a display name on some services.
           default_visibility: Visibility

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -136,8 +136,7 @@ en:
         cant_create_actor_for_model_type: "Cannot create an actor for %{model_type} %{model_id}"
         not_allowed_to_create_actor_for_model: "Not allowed to create an actor for %{model_id}"
         no_options: "No options passed to ActorHandler"
-        no_change_when_set: An ActivityPub username can't be changed once set.
-        invalid_username: "ActivityPub usernames can only contain ASCII characters."
+        invalid_username: "username must be 3 or more letters or numbers with no spaces."
         username_taken: "That username is already taken on this server."
     auth:
       error:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -136,7 +136,7 @@ en:
         cant_create_actor_for_model_type: "Cannot create an actor for %{model_type} %{model_id}"
         not_allowed_to_create_actor_for_model: "Not allowed to create an actor for %{model_id}"
         no_options: "No options passed to ActorHandler"
-        invalid_username: "username must be 3 or more letters or numbers with no spaces."
+        invalid_username: "Username must be %{min_length} to %{max_length} letters, numbers, dashes or underscores."
         username_taken: "That username is already taken on this server."
     auth:
       error:

--- a/lib/discourse_activity_pub/actor_handler.rb
+++ b/lib/discourse_activity_pub/actor_handler.rb
@@ -243,7 +243,12 @@ module DiscourseActivityPub
     end
 
     def invalid_opt(key)
-      add_error(I18n.t("discourse_activity_pub.actor.warning.#{key}"))
+      opts = {}
+      if key == "invalid_username"
+        opts[:min_length] = SiteSetting.min_username_length
+        opts[:max_length] = SiteSetting.max_username_length
+      end
+      add_error(I18n.t("discourse_activity_pub.actor.warning.#{key}", opts))
       false
     end
 

--- a/lib/discourse_activity_pub/actor_handler.rb
+++ b/lib/discourse_activity_pub/actor_handler.rb
@@ -192,11 +192,6 @@ module DiscourseActivityPub
       DiscourseActivityPubActor.username_unique?(username, model_id: model.id)
     end
 
-    def username_changed?
-      (opts[:username].present? && actor && actor.username.present?) &&
-        actor.username != opts[:username]
-    end
-
     def valid_actor?
       if !actor&.ap&.can_belong_to&.include?(model_type.downcase.to_sym)
         add_error(
@@ -240,7 +235,6 @@ module DiscourseActivityPub
       return invalid_opt("no_options") if opts.blank?
 
       if opts[:username].present?
-        return invalid_opt("no_change_when_set") if username_changed?
         return invalid_opt("invalid_username") if !valid_actor_username?(opts[:username])
         return invalid_opt("username_taken") if !unique_actor_username?(opts[:username])
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1068,6 +1068,9 @@ after_initialize do
           )
       else
         actor.stored.name = actor.json[:name] if actor.json[:name].present?
+        actor.stored.username = actor.json[:preferredUsername] if actor.json[
+          :preferredUsername
+        ].present?
 
         if actor.json[:icon].present?
           actor.stored.icon_url = DiscourseActivityPub::JsonLd.resolve_icon_url(actor.json[:icon])

--- a/spec/lib/discourse_activity_pub/actor_handler_spec.rb
+++ b/spec/lib/discourse_activity_pub/actor_handler_spec.rb
@@ -266,26 +266,11 @@ RSpec.describe DiscourseActivityPub::ActorHandler do
           context "with a changed username" do
             let!(:original_username) { actor.username }
 
-            before { setup_logging }
-            after { teardown_logging }
-
-            it "does not update the username" do
+            it "updates the username" do
               opts[:username] = "new_username"
               described_class.update_or_create_actor(category, opts)
-              expect(actor.reload.username).to eq(original_username)
-              expect(category.reload.activity_pub_username).to eq(original_username)
-            end
-
-            it "logs an error" do
-              opts[:username] = "new_username"
-              described_class.update_or_create_actor(category, opts)
-              expect(@fake_logger.warnings.first).to match(
-                I18n.t(
-                  "discourse_activity_pub.actor.warning.no_change_when_set",
-                  model_id: category.id,
-                  model_type: category.class.name,
-                ),
-              )
+              expect(actor.reload.username).to eq("new_username")
+              expect(category.reload.activity_pub_username).to eq("new_username")
             end
           end
         end

--- a/spec/lib/discourse_activity_pub/actor_handler_spec.rb
+++ b/spec/lib/discourse_activity_pub/actor_handler_spec.rb
@@ -293,8 +293,8 @@ RSpec.describe DiscourseActivityPub::ActorHandler do
               expect(@fake_logger.warnings.first).to match(
                 I18n.t(
                   "discourse_activity_pub.actor.warning.invalid_username",
-                  model_id: category.id,
-                  model_type: category.class.name,
+                  min_length: SiteSetting.min_username_length,
+                  max_length: SiteSetting.max_username_length,
                 ),
               )
             end

--- a/spec/lib/discourse_activity_pub/ap/actor_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/actor_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DiscourseActivityPub::AP::Actor do
       expect(actor.name).to eq(json["name"])
     end
 
-    it "updates an actor if optional attributes have changed" do
+    it "updates name if name has changed" do
       perform
 
       actor = DiscourseActivityPubActor.find_by(ap_id: json["id"])
@@ -35,7 +35,19 @@ RSpec.describe DiscourseActivityPub::AP::Actor do
       expect(actor.name).to eq("Bob McLeod")
     end
 
-    it "creates a new actor if required attributes have changed" do
+    it "updates username if preferredUsername has changed" do
+      perform
+
+      actor = DiscourseActivityPubActor.find_by(ap_id: json["id"])
+      expect(actor.username).to eq("angus")
+
+      perform(preferredUsername: "bob")
+
+      actor = DiscourseActivityPubActor.find_by(ap_id: json["id"])
+      expect(actor.username).to eq("bob")
+    end
+
+    it "creates a new actor if id has changed" do
       perform
 
       original_id = json["id"]

--- a/spec/requests/discourse_activity_pub/admin/actor_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/admin/actor_controller_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe DiscourseActivityPub::Admin::ActorController do
       end
 
       context "with a new username" do
-        it "returns an udpated actor" do
+        it "returns an updated actor" do
           put "/admin/plugins/ap/actor/#{actor.id}.json",
               params: {
                 actor: {

--- a/spec/requests/discourse_activity_pub/admin/actor_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/admin/actor_controller_spec.rb
@@ -254,15 +254,15 @@ RSpec.describe DiscourseActivityPub::Admin::ActorController do
       end
 
       context "with a new username" do
-        it "returns the right error" do
+        it "returns an updated actor" do
           put "/admin/plugins/ap/actor/#{actor.id}.json",
               params: {
                 actor: {
                   username: "new_actor",
                 },
               }
-          expect(response.status).to eq(400)
-          expect(response.parsed_body["errors"]).to include(actor_warning("no_change_when_set"))
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["actor"]["username"]).to eq("new_actor")
         end
       end
 
@@ -296,15 +296,15 @@ RSpec.describe DiscourseActivityPub::Admin::ActorController do
       end
 
       context "with a new username" do
-        it "returns the right error" do
+        it "returns an udpated actor" do
           put "/admin/plugins/ap/actor/#{actor.id}.json",
               params: {
                 actor: {
                   username: "new_actor",
                 },
               }
-          expect(response.status).to eq(400)
-          expect(response.parsed_body["errors"]).to include(actor_warning("no_change_when_set"))
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["actor"]["username"]).to eq("new_actor")
         end
       end
 


### PR DESCRIPTION
The following will happen on remote services if you change the username:

- Mastodon: The username displayed for the actor will not change until someone performs a lookup of the new handle. Following / Posting etc will continue to work regardless of the username displayed.

- Discourse: The username will be updated the next time there is any interaction with the actor, including:
   - any activities are received from the actor; and
   - the actor is the subject of a lookup in the "Follow" modal.

See further: https://socialhub.activitypub.rocks/t/changeable-usernames/830/13?u=angus