### PR TITLE
DEV: Allow system user to be an actor

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -578,7 +578,7 @@ after_initialize do
 
   add_to_class(:user, :activity_pub_enabled) { DiscourseActivityPub.enabled }
   add_to_class(:user, :activity_pub_ready?) { true }
-  add_to_class(:user, :activity_pub_allowed?) { self.human? }
+  add_to_class(:user, :activity_pub_allowed?) { true }
   add_to_class(:user, :activity_pub_url) { full_url }
   add_to_class(:user, :activity_pub_icon_url) { avatar_template_url.gsub("{size}", "96") }
   add_to_class(:user, :activity_pub_save_access_token) do |domain, access_token|

--- a/spec/lib/discourse_activity_pub/actor_handler_spec.rb
+++ b/spec/lib/discourse_activity_pub/actor_handler_spec.rb
@@ -193,6 +193,15 @@ RSpec.describe DiscourseActivityPub::ActorHandler do
       end
     end
 
+    context "with a non-human user" do
+      let!(:user) { Discourse.system_user }
+
+      it "creates an actor" do
+        actor = described_class.update_or_create_actor(user)
+        expect(actor.reload.model_id).to eq(user.id)
+      end
+    end
+
     context "with a category" do
       let!(:category) { Fabricate(:category) }
 


### PR DESCRIPTION
This restriction keeps topics authored by system users from being published. There's no current need for this restriction.