### PR TITLE
FIX: Bulk process ensure unique collections

### DIFF
--- a/lib/discourse_activity_pub/bulk/process.rb
+++ b/lib/discourse_activity_pub/bulk/process.rb
@@ -658,6 +658,7 @@ module DiscourseActivityPub
               reply_to_id
               url
               attributed_to_id
+              collection_id
             ],
             returning: Arel.sql("*, (xmax = '0') as inserted"),
           )


### PR DESCRIPTION
I can't reproduce this in a spec yet, however this ap_id uniqueness check prevents exceptions that can occur when using bulk process the wild. Note that if you pass objects with duplicate unique_by attributes upsert_all will not resolve the duplication and throw and error.