### PR TITLE
DEV: Don’t replace Rails logger in specs

### DIFF
--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -343,13 +343,13 @@ def expect_post(returns: true)
 end
 
 def setup_logging
+  @fake_logger = FakeLogger.new
   SiteSetting.activity_pub_verbose_logging = true
-  @orig_logger = Rails.logger
-  Rails.logger = @fake_logger = FakeLogger.new
+  Rails.logger.broadcast_to(@fake_logger)
 end
 
 def teardown_logging
-  Rails.logger = @orig_logger
+  Rails.logger.stop_broadcasting_to(@fake_logger)
   SiteSetting.activity_pub_verbose_logging = false
 end
 


### PR DESCRIPTION
Instead of replacing the Rails logger in specs, we can instead use broadcast_to which has been introduced in Rails 7.