### PR TITLE
DEV: Correct handling of empty Accept headers

### DIFF
--- a/lib/discourse_activity_pub/json_ld.rb
+++ b/lib/discourse_activity_pub/json_ld.rb
@@ -75,6 +75,7 @@ module DiscourseActivityPub
     end
 
     def valid_accept?(value)
+      return false if value.blank?
       value.split(",").compact.collect(&:strip).all? { |v| valid_content_type?(v) }
     end
 

--- a/spec/lib/discourse_activity_pub/json_ld_spec.rb
+++ b/spec/lib/discourse_activity_pub/json_ld_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe DiscourseActivityPub::JsonLd do
         false,
       )
     end
+
+    it "does not validate empty accept headers" do
+      expect(described_class.valid_accept?(nil)).to eq(false)
+    end
   end
 
   describe "#address_json" do


### PR DESCRIPTION
Occasionally seeing these log entries: 

```
NoMethodError (undefined method `split' for nil)

plugins/discourse-activity-pub/lib/discourse_activity_pub/json_ld.rb:78:in `valid_accept?'
plugins/discourse-activity-pub/app/controllers/discourse_activity_pub/ap/objects_controller.rb:64:in `validate_headers'
activesupport (7.1.5) lib/active_support/callbacks.rb:403:in `block in make_lambda'
```

I'm only going via specs here, this looks fine @angusmcleod? 