### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/activity-pub-authorization.hbs
+++ b/assets/javascripts/discourse/components/activity-pub-authorization.hbs
@@ -9,7 +9,7 @@
     {{@authorization.actor_id}}
   </a>
   <DButton
-    @icon="times"
+    @icon="xmark"
     @action={{action "remove"}}
     @title="user.discourse_activity_pub.remove_authorization_button.title"
     id="user_activity_pub_authorize_remove_authorization"

--- a/assets/javascripts/discourse/components/activity-pub-authorize.hbs
+++ b/assets/javascripts/discourse/components/activity-pub-authorize.hbs
@@ -8,7 +8,7 @@
       <span class="activity-pub-authorize-verified-domain">
         <a class="btn">{{this.domain}}</a>
         <DButton
-          @icon="times"
+          @icon="xmark"
           @action={{action "clearDomain"}}
           @title="user.discourse_activity_pub.clear_domain_button.title"
           id="user_activity_pub_authorize_clear_domain"

--- a/assets/javascripts/discourse/components/activity-pub-follow-btn.gjs
+++ b/assets/javascripts/discourse/components/activity-pub-follow-btn.gjs
@@ -41,7 +41,7 @@ export default class ActivityPubFollowBtn extends Component {
   get icon() {
     switch (this.args.type) {
       case "follow":
-        return "external-link-alt";
+        return "up-right-from-square";
       case "actor_follow":
         return "plus";
       case "actor_unfollow":

--- a/assets/javascripts/discourse/components/activity-pub-follow-domain.hbs
+++ b/assets/javascripts/discourse/components/activity-pub-follow-domain.hbs
@@ -8,7 +8,7 @@
       id="activity_pub_follow_domain_input"
     />
     <DButton
-      @icon="external-link-alt"
+      @icon="up-right-from-square"
       @action={{action "follow"}}
       @label="discourse_activity_pub.follow.domain.btn_label"
       @title="discourse_activity_pub.follow.domain.btn_title"

--- a/assets/javascripts/discourse/components/modal/activity-pub-actor-follow.hbs
+++ b/assets/javascripts/discourse/components/modal/activity-pub-actor-follow.hbs
@@ -14,7 +14,7 @@
             {{on "keyup" this.onKeyup}}
           />
           <DButton
-            @icon="search"
+            @icon="magnifying-glass"
             @action={{action "find"}}
             @label="discourse_activity_pub.actor_follow.find.btn_label"
             @title="discourse_activity_pub.actor_follow.find.btn_title"

--- a/assets/javascripts/discourse/templates/admin-plugins-activity-pub-actor.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-activity-pub-actor.hbs
@@ -47,7 +47,7 @@
                 @action={{action "editActor" actor}}
                 @label="admin.discourse_activity_pub.actor.edit.label"
                 @title="admin.discourse_activity_pub.actor.edit.title"
-                @icon="pencil-alt"
+                @icon="pencil"
                 class="activity-pub-actor-edit-btn"
               />
             </div>


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.