### PR TITLE
Redirect ap url requests from browser to associated model url

### DIFF
--- a/app/controllers/discourse_activity_pub/ap/actors_controller.rb
+++ b/app/controllers/discourse_activity_pub/ap/actors_controller.rb
@@ -7,7 +7,11 @@ class DiscourseActivityPub::AP::ActorsController < DiscourseActivityPub::AP::Obj
   before_action :ensure_actor_ready
 
   def show
-    render_activity_json(@actor.ap.json)
+    if browser_request?
+      redirect_to @actor.model.activity_pub_url
+    else
+      render_activity_json(@actor.ap.json)
+    end
   end
 
   protected

--- a/spec/requests/discourse_activity_pub/ap/actors_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/actors_controller_spec.rb
@@ -81,5 +81,18 @@ RSpec.describe DiscourseActivityPub::AP::ActorsController do
       expect(response.status).to eq(200)
       expect(parsed_body).to eq(group.reload.ap.json)
     end
+
+    context "when requested from a browser" do
+      let(:browser_user_agent) do
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edg/75.10240"
+      end
+
+      context "with a group actor" do
+        it "redirects to the group model url" do
+          get_object(group, headers: { "HTTP_USER_AGENT" => browser_user_agent })
+          expect(response).to redirect_to(group.model.url)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
@pmusaraj This change means that when you use this URI in a browser you'll be redirected to the relevant post.

<img width="600" alt="Screenshot at Jan 03 17-07-56" src="https://github.com/user-attachments/assets/cbfe28eb-73dd-467b-9054-4de1c027503e" />