### PR TITLE
Restrict domain allow / deny functionality to domains verified via signature

### DIFF
--- a/app/controllers/concerns/discourse_activity_pub/domain_verification.rb
+++ b/app/controllers/concerns/discourse_activity_pub/domain_verification.rb
@@ -1,18 +1,10 @@
 # frozen_string_literal: true
 module DiscourseActivityPub
   module DomainVerification
-    def ensure_domain_allowed
-      render_activity_pub_error("forbidden", 403) unless domain_allowed?(request_domain)
-    end
-
     def domain_allowed?(domain)
       return allowed_domains.include?(domain) if allowed_domains.any?
       return blocked_domains.exclude?(domain) if blocked_domains.any?
       true
-    end
-
-    def request_domain
-      DiscourseActivityPub::URI.domain_from_uri(request.origin)
     end
 
     def allowed_domains

--- a/app/controllers/discourse_activity_pub/ap/objects_controller.rb
+++ b/app/controllers/discourse_activity_pub/ap/objects_controller.rb
@@ -17,7 +17,6 @@ class DiscourseActivityPub::AP::ObjectsController < ApplicationController
   before_action :ensure_site_enabled
   before_action :ensure_request_permitted
   before_action :validate_headers, unless: :browser_request?
-  before_action :ensure_domain_allowed
   before_action :ensure_object_exists, if: :is_object_controller
   before_action :ensure_model_exists, if: -> { is_object_controller && browser_request? }
   before_action :set_raw_body

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -266,3 +266,5 @@ en:
     activity_pub_verbose_logging: "Enable verbose ActivityPub logs."
     activity_pub_object_logging: "Print all incoming and outgoing ActivityPub objects in the logs (requires verbose logging)."
     activity_pub_post_status_visibility_groups: "Groups who can see ActivityPub post statuses."
+    errors:
+      signed_requests_required: Signed requests are required for this setting.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,10 +16,12 @@ discourse_activity_pub:
     default: ""
     type: host_list
     list_type: simple
+    validator: "ActivityPubSignedRequestsValidator"
   activity_pub_blocked_request_origins:
     default: ""
     type: host_list
     list_type: simple
+    validator: "ActivityPubSignedRequestsValidator"
   activity_pub_delivery_delay_minutes:
     default: 5
     min: 1

--- a/plugin.rb
+++ b/plugin.rb
@@ -13,6 +13,8 @@ register_svg_icon "user-check"
 
 add_admin_route "admin.discourse_activity_pub.label", "activityPub"
 
+require_relative "validators/activity_pub_signed_requests_validator.rb"
+
 after_initialize do
   require_relative "lib/discourse_activity_pub/engine"
   require_relative "lib/discourse_activity_pub/json_ld"

--- a/spec/fabricators/discourse_activity_pub_actor_fabricator.rb
+++ b/spec/fabricators/discourse_activity_pub_actor_fabricator.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 Fabricator(:discourse_activity_pub_actor) do
+  transient :actor_domain
   ap_type { "Actor" }
   domain { DiscourseActivityPub.host }
   username { sequence(:username) { |i| "username#{i}" } }
 
-  before_create do
-    self.domain = "remote.com" unless local
+  before_create do |actor, transient|
+    self.domain = (transient[:actor_domain] || "remote.com") unless local
     self.ap_id = "https://#{self.domain}/actor/#{SecureRandom.hex(16)}" unless self.ap_id || local
   end
 

--- a/spec/requests/discourse_activity_pub/ap/objects_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/objects_controller_spec.rb
@@ -92,41 +92,6 @@ RSpec.describe DiscourseActivityPub::AP::ObjectsController do
     end
   end
 
-  context "with allowed domains" do
-    before do
-      SiteSetting.activity_pub_allowed_request_origins = "allowed.com"
-      setup_logging
-    end
-
-    it "allows allowed domains" do
-      get_object(object, headers: { ORIGIN: "https://allowed.com" })
-      expect(response.status).to eq(200)
-    end
-
-    it "blocks not allowed domains" do
-      get_object(object, headers: { ORIGIN: "https://notallowed.com" })
-      expect_request_error(response, "forbidden", 403)
-    end
-  end
-
-  context "with blocked domains" do
-    before do
-      SiteSetting.activity_pub_blocked_request_origins = "notallowed.com"
-      setup_logging
-    end
-    after { teardown_logging }
-
-    it "blocks blocked domains" do
-      get_object(object, headers: { ORIGIN: "https://notallowed.com" })
-      expect_request_error(response, "forbidden", 403)
-    end
-
-    it "allows unblocked domains" do
-      get_object(object, headers: { ORIGIN: "https://allowed.com" })
-      expect(response.status).to eq(200)
-    end
-  end
-
   describe "#show" do
     context "when not requested from a browser" do
       it "returns object json with addressing" do

--- a/validators/activity_pub_signed_requests_validator.rb
+++ b/validators/activity_pub_signed_requests_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ActivityPubSignedRequestsValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    return true if val == "f"
+    SiteSetting.activity_pub_require_signed_requests
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.signed_requests_required")
+  end
+end


### PR DESCRIPTION
See further: https://meta.discourse.org/t/how-to-debug-connectivity-issues-with-activitypub/345798. Note that domain verification is already applied in the signature verification logic [here](https://github.com/discourse/discourse-activity-pub/blob/main/app/controllers/concerns/discourse_activity_pub/signature_verification.rb#L234).