### PR TITLE
Add log records and list them in plugin admin

### DIFF
--- a/app/controllers/discourse_activity_pub/admin/log_controller.rb
+++ b/app/controllers/discourse_activity_pub/admin/log_controller.rb
@@ -3,10 +3,7 @@
 module DiscourseActivityPub
   module Admin
     class LogController < DiscourseActivityPub::Admin::AdminController
-
-      ORDER_BY = {
-        "level" => "level"
-      }
+      ORDER_BY = { "level" => "level" }
 
       def index
         logs = DiscourseActivityPubLog.all

--- a/app/controllers/discourse_activity_pub/admin/log_controller.rb
+++ b/app/controllers/discourse_activity_pub/admin/log_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module DiscourseActivityPub
+  module Admin
+    class LogController < DiscourseActivityPub::Admin::AdminController
+
+      ORDER_BY = {
+        "level" => "level"
+      }
+
+      def index
+        logs = DiscourseActivityPubLog.all
+
+        offset = params[:offset].to_i || 0
+        load_more_query_params = { offset: offset + 1 }
+        load_more_query_params[:order] = params[:order] if !params[:order].nil?
+        load_more_query_params[:asc] = params[:asc] if !params[:asc].nil?
+
+        total = logs.count
+        order = ORDER_BY.fetch(params[:order], "created_at")
+        direction = params[:asc] == "true" ? "ASC" : "DESC"
+        logs = logs.order("#{order} #{direction}").limit(page_limit).offset(offset * page_limit)
+
+        load_more_url = URI("/admin/plugins/ap/log.json")
+        load_more_url.query = ::URI.encode_www_form(load_more_query_params)
+
+        render_serialized(
+          logs,
+          DiscourseActivityPub::Admin::LogSerializer,
+          root: "logs",
+          meta: {
+            total: total,
+            load_more_url: load_more_url.to_s,
+          },
+        )
+      end
+
+      protected
+
+      def page_limit
+        30
+      end
+    end
+  end
+end

--- a/app/jobs/discourse_activity_pub_log_rotate.rb
+++ b/app/jobs/discourse_activity_pub_log_rotate.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 module Jobs
-  class UpdateHeatSettings < ::Jobs::Scheduled
+  class DiscourseActivityPubLogRotate < ::Jobs::Scheduled
     every 1.day
 
     def execute(args)
-      DiscourseActivityPubLog
-        .where("created_at < ?", SiteSetting.activity_pub_logs_max_days_old.days.ago)
-        .destroy_all
+      return if !SiteSetting.activity_pub_enabled
+
+      DiscourseActivityPubLog.where(
+        "created_at < ?",
+        SiteSetting.activity_pub_logs_max_days_old.days.ago,
+      ).destroy_all
     end
   end
 end

--- a/app/jobs/discourse_activity_pub_log_rotate.rb
+++ b/app/jobs/discourse_activity_pub_log_rotate.rb
@@ -5,8 +5,6 @@ module Jobs
     every 1.day
 
     def execute(args)
-      return if !SiteSetting.activity_pub_enabled
-
       DiscourseActivityPubLog.where(
         "created_at < ?",
         SiteSetting.activity_pub_logs_max_days_old.days.ago,

--- a/app/jobs/discourse_activity_pub_log_rotate.rb
+++ b/app/jobs/discourse_activity_pub_log_rotate.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Jobs
+  class UpdateHeatSettings < ::Jobs::Scheduled
+    every 1.day
+
+    def execute(args)
+      DiscourseActivityPubLog
+        .where("created_at < ?", SiteSetting.activity_pub_logs_max_days_old.days.ago)
+        .destroy_all
+    end
+  end
+end

--- a/app/models/discourse_activity_pub_log.rb
+++ b/app/models/discourse_activity_pub_log.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class DiscourseActivityPubLog < ActiveRecord::Base
+  enum :level, %i[info warn error]
+
+  validates :message, presence: true
+  validates :level, presence: true
+end

--- a/app/models/discourse_activity_pub_log.rb
+++ b/app/models/discourse_activity_pub_log.rb
@@ -6,3 +6,15 @@ class DiscourseActivityPubLog < ActiveRecord::Base
   validates :message, presence: true
   validates :level, presence: true
 end
+
+# == Schema Information
+#
+# Table name: discourse_activity_pub_logs
+#
+#  id         :bigint           not null, primary key
+#  level      :integer
+#  message    :string
+#  json       :json
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/app/serializers/discourse_activity_pub/admin/log_serializer.rb
+++ b/app/serializers/discourse_activity_pub/admin/log_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module DiscourseActivityPub
+  class Admin::LogSerializer < ActiveModel::Serializer
+    attributes :id, :created_at, :level, :message, :json
+  end
+end

--- a/assets/javascripts/discourse/activity-pub-admin-route-map.js
+++ b/assets/javascripts/discourse/activity-pub-admin-route-map.js
@@ -5,6 +5,7 @@ export default {
     this.route("activityPub", { path: "/ap" }, function () {
       this.route("actor");
       this.route("actorShow", { path: "/actor/:actor_id" });
+      this.route("log");
     });
   },
 };

--- a/assets/javascripts/discourse/components/modal/activity-pub-log-json.hbs
+++ b/assets/javascripts/discourse/components/modal/activity-pub-log-json.hbs
@@ -1,0 +1,35 @@
+<DModal
+  @closeModal={{@closeModal}}
+  @title={{i18n "admin.discourse_activity_pub.log.json.title"}}
+  class="activity-pub-json-modal"
+>
+  <:body>
+    <div class="activity-pub-json-modal-header">
+      <div class="activity-pub-json-modal-title">
+        {{htmlSafe
+          (i18n
+            "admin.discourse_activity_pub.log.json.logged_at"
+            logged_at=(formatDate
+              @model.log.created_at format="medium" leaveAgo="true"
+            )
+          )
+        }}
+      </div>
+      <div class="activity-pub-json-modal-buttons">
+        {{#if this.copied}}
+          <span class="activity-pub-json-copy-status success">
+            {{i18n "admin.discourse_activity_pub.log.json.copy.success"}}
+          </span>
+        {{/if}}
+        <DButton
+          @action={{this.copyToClipboard}}
+          @icon="copy"
+          @label="admin.discourse_activity_pub.log.json.copy.label"
+          @title="admin.discourse_activity_pub.log.json.copy.title"
+          class="activity-pub-json-copy-btn btn-default"
+        />
+      </div>
+    </div>
+    <pre class="activity-pub-json-display">{{this.jsonDisplay}}</pre>
+  </:body>
+</DModal>

--- a/assets/javascripts/discourse/components/modal/activity-pub-log-json.js
+++ b/assets/javascripts/discourse/components/modal/activity-pub-log-json.js
@@ -1,0 +1,22 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { clipboardCopy } from "discourse/lib/utilities";
+import discourseLater from "discourse-common/lib/later";
+
+export default class ActivityPubLogJson extends Component {
+  @tracked copied = false;
+
+  get jsonDisplay() {
+    return JSON.stringify(this.args.model.log.json, null, 4);
+  }
+
+  @action
+  copyToClipboard() {
+    clipboardCopy(this.args.model.log.json);
+    this.copied = true;
+    discourseLater(() => {
+      this.copied = false;
+    }, 3000);
+  }
+}

--- a/assets/javascripts/discourse/controllers/admin-plugins-activity-pub-log.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-activity-pub-log.js
@@ -1,0 +1,65 @@
+import { tracked } from "@glimmer/tracking";
+import Controller from "@ember/controller";
+import { action } from "@ember/object";
+import { notEmpty } from "@ember/object/computed";
+import { service } from "@ember/service";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import ActivityPubLogJsonModal from "../components/modal/activity-pub-log-json";
+import ActivityPubLog from "../models/activity-pub-log";
+
+export default class AdminPluginsActivityPubLog extends Controller {
+  @service modal;
+  @service router;
+  @tracked order = "";
+  @tracked asc = null;
+  loadMoreUrl = "";
+  total = "";
+
+  @notEmpty("logs") hasLogs;
+
+  queryParams = ["order", "asc"];
+
+  @action
+  loadMore() {
+    if (!this.loadMoreUrl || this.total <= this.logs.length) {
+      return;
+    }
+
+    this.set("loadingMore", true);
+
+    return ajax(this.loadMoreUrl)
+      .then((response) => {
+        if (response) {
+          this.logs.pushObjects(
+            (response.logs || []).map((log) => {
+              return ActivityPubLog.create(log);
+            })
+          );
+          this.setProperties({
+            loadMoreUrl: response.meta.load_more_url,
+            total: response.meta.total,
+            loadingMore: false,
+          });
+        }
+      })
+      .catch(popupAjaxError);
+  }
+
+  @action
+  updateOrder(field, asc) {
+    this.setProperties({
+      order: field,
+      asc,
+    });
+  }
+
+  @action
+  showJson(log) {
+    this.modal.show(ActivityPubLogJsonModal, {
+      model: {
+        log,
+      },
+    });
+  }
+}

--- a/assets/javascripts/discourse/models/activity-pub-log.js
+++ b/assets/javascripts/discourse/models/activity-pub-log.js
@@ -1,0 +1,32 @@
+import EmberObject from "@ember/object";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+
+export const logAdminPath = "/admin/plugins/ap/log";
+
+class ActivityPubLog extends EmberObject {}
+
+ActivityPubLog.reopenClass({
+  list(params) {
+    const queryParams = new URLSearchParams();
+
+    if (params.order) {
+      queryParams.set("order", params.order);
+    }
+
+    if (params.asc) {
+      queryParams.set("asc", params.asc);
+    }
+
+    const path = logAdminPath;
+
+    let url = `${path}.json`;
+    if (queryParams.size) {
+      url += `?${queryParams.toString()}`;
+    }
+
+    return ajax(url).catch(popupAjaxError);
+  },
+});
+
+export default ActivityPubLog;

--- a/assets/javascripts/discourse/routes/admin-plugins-activity-pub-log.js
+++ b/assets/javascripts/discourse/routes/admin-plugins-activity-pub-log.js
@@ -1,0 +1,24 @@
+import { A } from "@ember/array";
+import DiscourseRoute from "discourse/routes/discourse";
+import ActivityPubLog from "../models/activity-pub-log";
+
+export default class AdminPluginsActivityPubLogRoute extends DiscourseRoute {
+  queryParams = {
+    order: { refreshModel: true },
+    asc: { refreshModel: true },
+  };
+
+  model(params) {
+    return ActivityPubLog.list(params);
+  }
+
+  setupController(controller, model) {
+    controller.setProperties({
+      logs: A(
+        (model.logs || []).map((actor) => {
+          return ActivityPubLog.create(actor);
+        })
+      ),
+    });
+  }
+}

--- a/assets/javascripts/discourse/templates/admin-plugins-activity-pub-log.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-activity-pub-log.hbs
@@ -1,0 +1,76 @@
+<div class="admin-title activity-pub-log-title">
+  <h2>{{i18n "admin.discourse_activity_pub.log.title"}}</h2>
+</div>
+
+<LoadMore
+  @selector=".directory-table .directory-table__cell"
+  @action={{action "loadMore"}}
+  class="activity-pub-logs-container"
+>
+  {{#if this.hasLogs}}
+    <ResponsiveTable @className="activity-pub-log-table">
+      <:header>
+        <TableHeaderToggle
+          @onToggle={{this.updateOrder}}
+          @field="created_at"
+          @labelKey="admin.discourse_activity_pub.log.created_at"
+          @automatic={{true}}
+          @order={{this.order}}
+          @asc={{this.asc}}
+        />
+        <TableHeaderToggle
+          @onToggle={{this.updateOrder}}
+          @field="level"
+          @labelKey="admin.discourse_activity_pub.log.level"
+          @automatic={{true}}
+          @order={{this.order}}
+          @asc={{this.asc}}
+        />
+        <TableHeaderToggle
+          @field="message"
+          @labelKey="admin.discourse_activity_pub.log.message"
+          @automatic={{true}}
+          @order={{this.order}}
+          @asc={{this.asc}}
+        />
+        <div
+          class="activity-pub-json-table-json directory-table__column-header"
+        >
+          <div class="header-contents">
+            {{i18n "admin.discourse_activity_pub.log.json.label"}}
+          </div>
+        </div>
+      </:header>
+      <:body>
+        {{#each this.logs as |log|}}
+          <div class="directory-table__row activity-pub-log-row">
+            <div class="directory-table__cell activity-pub-log-created-at">
+              {{formatDate log.created_at leaveAgo="true"}}
+            </div>
+            <div class="directory-table__cell activity-pub-log-level">
+              {{log.level}}
+            </div>
+            <div class="directory-table__cell activity-pub-log-message">
+              {{log.message}}
+            </div>
+            <div class="directory-table__cell activity-pub-log-json">
+              {{#if log.json}}
+                <DButton
+                  @action={{action "showJson" log}}
+                  @icon="code"
+                  @label="admin.discourse_activity_pub.log.json.show.label"
+                  @title="admin.discourse_activity_pub.log.json.show.title"
+                  class="activity-pub-log-show-json-btn"
+                />
+              {{/if}}
+            </div>
+          </div>
+        {{/each}}
+      </:body>
+    </ResponsiveTable>
+
+    <ConditionalLoadingSpinner @condition={{this.loadingMore}} />
+  {{else}}
+    <p>{{i18n "search.no_results"}}</p>
+  {{/if}}
+</LoadMore>

--- a/assets/javascripts/discourse/templates/admin-plugins-activity-pub.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-activity-pub.hbs
@@ -15,6 +15,11 @@
       <span>{{i18n "admin.discourse_activity_pub.actor.tag.label"}}</span>
     </LinkTo>
   </li>
+  <li>
+    <LinkTo @route="adminPlugins.activityPub.log">
+      <span>{{i18n "admin.discourse_activity_pub.log.label"}}</span>
+    </LinkTo>
+  </li>
   <li class="activity-pub-add-actor">
     <LinkTo
       @route="adminPlugins.activityPub.actorShow"

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -463,7 +463,37 @@ body.user-preferences-activity-pub-page {
   }
 }
 
-.activity-pub-actor-title {
+.activity-pub-log-table {
+  grid-template-columns: 120px 100px minmax(8em, 2fr) 120px;
+}
+
+.activity-pub-log-created-at {
+  justify-content: flex-start;
+}
+
+.activity-pub-json-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.activity-pub-json-modal-buttons {
+  display: flex;
+  gap: 0.5em;
+  align-items: center;
+}
+
+.activity-pub-json-display {
+  max-width: 100%;
+  max-height: 400px;
+  font-size: 0.8em;
+  background-color: var(--primary-100);
+  padding: 0.5em;
+  overflow: scroll;
+}
+
+.activity-pub-actor-title,
+.activity-pub-log-title {
   align-items: center;
   gap: 1em;
   margin-top: 1em;
@@ -502,7 +532,8 @@ body.user-preferences-activity-pub-page {
   }
 }
 
-.activity-pub-actor-save-response {
+.activity-pub-actor-save-response,
+.activity-pub-json-copy-status {
   &.success {
     color: var(--success);
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -63,6 +63,21 @@ en:
             tag: Tag
         log:
           label: Logs
+          title: Logs
+          created_at: Created At
+          level: Level
+          message: Message
+          json:
+            label: JSON
+            title: Activity JSON
+            show:
+              label: JSON
+              title: Show Activity JSON
+            copy:
+              label: Copy
+              title: Copy JSON to clipboard.
+              success: Copied!
+            logged_at: Logged %{logged_at}
   js:   
     discourse_activity_pub:
       status:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -267,5 +267,6 @@ en:
     activity_pub_verbose_logging: "Enable verbose ActivityPub logs."
     activity_pub_object_logging: "Print all incoming and outgoing ActivityPub objects in the logs (requires verbose logging)."
     activity_pub_post_status_visibility_groups: "Groups who can see ActivityPub post statuses."
+    activity_pub_logs_max_days_old: "How many days ActivityPub logs are kept for."
     errors:
       signed_requests_required: Signed requests are required for this setting.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,3 +36,7 @@ discourse_activity_pub:
     default: false
   activity_pub_object_logging:
     default: false
+  activity_pub_logs_max_days_old:
+    default: 60
+    min: 7
+    max: 36500

--- a/db/migrate/20250109115337_create_discourse_activity_pub_logs.rb
+++ b/db/migrate/20250109115337_create_discourse_activity_pub_logs.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class CreateDiscourseActivityPubLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :discourse_activity_pub_logs do |t|
+      t.integer :level
+      t.string :message
+      t.json :json
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/discourse_activity_pub/logger.rb
+++ b/lib/discourse_activity_pub/logger.rb
@@ -13,7 +13,11 @@ module DiscourseActivityPub
     end
 
     def log(message, json: nil)
+      return if self.class.log_types.exclude?(type)
+
       puts formatted_message(message) if print_to_stdout?
+
+      DiscourseActivityPubLog.create(level: type, message: message, json: json)
 
       return unless SiteSetting.activity_pub_verbose_logging
       rails_args = {}

--- a/plugin.rb
+++ b/plugin.rb
@@ -79,6 +79,7 @@ after_initialize do
   require_relative "app/models/discourse_activity_pub_authorization"
   require_relative "app/models/discourse_activity_pub_client"
   require_relative "app/models/discourse_activity_pub_follow"
+  require_relative "app/models/discourse_activity_pub_log"
   require_relative "app/models/discourse_activity_pub_object"
   require_relative "app/models/discourse_activity_pub_collection"
   require_relative "app/jobs/discourse_activity_pub_process"
@@ -98,6 +99,7 @@ after_initialize do
   require_relative "app/controllers/discourse_activity_pub/webfinger/handle_controller"
   require_relative "app/controllers/discourse_activity_pub/admin/admin_controller"
   require_relative "app/controllers/discourse_activity_pub/admin/actor_controller"
+  require_relative "app/controllers/discourse_activity_pub/admin/log_controller"
   require_relative "app/controllers/discourse_activity_pub/authorization_controller"
   require_relative "app/controllers/discourse_activity_pub/post_controller"
   require_relative "app/controllers/discourse_activity_pub/actor_controller"
@@ -127,6 +129,7 @@ after_initialize do
   require_relative "app/serializers/discourse_activity_pub/actor_serializer"
   require_relative "app/serializers/discourse_activity_pub/authorization_serializer"
   require_relative "app/serializers/discourse_activity_pub/admin/actor_serializer"
+  require_relative "app/serializers/discourse_activity_pub/admin/log_serializer"
   require_relative "config/routes"
   require_relative "extensions/discourse_activity_pub_guardian_extension"
 
@@ -1122,6 +1125,7 @@ after_initialize do
         put "ap/actor/:actor_id" => "admin/actor#update", :constraints => { format: :json }
         post "ap/actor/:actor_id/enable" => "admin/actor#enable"
         post "ap/actor/:actor_id/disable" => "admin/actor#disable"
+        get "ap/log" => "admin/log#index"
       end
     end
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -84,6 +84,7 @@ after_initialize do
   require_relative "app/models/discourse_activity_pub_collection"
   require_relative "app/jobs/discourse_activity_pub_process"
   require_relative "app/jobs/discourse_activity_pub_deliver"
+  require_relative "app/jobs/discourse_activity_pub_log_rotate"
   require_relative "app/controllers/concerns/discourse_activity_pub/domain_verification"
   require_relative "app/controllers/concerns/discourse_activity_pub/signature_verification"
   require_relative "app/controllers/concerns/discourse_activity_pub/enabled_verification"

--- a/spec/fabricators/discourse_activity_pub_log_fabricator.rb
+++ b/spec/fabricators/discourse_activity_pub_log_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:discourse_activity_pub_log) do
+  level { 1 } # warn
+  message { sequence(:message) { |i| "ActivityPub log message #{i}" } }
+end

--- a/spec/jobs/discourse_activity_pub_log_rotate_spec.rb
+++ b/spec/jobs/discourse_activity_pub_log_rotate_spec.rb
@@ -5,23 +5,11 @@ RSpec.describe Jobs::DiscourseActivityPubLogRotate do
   let!(:log2) { Fabricate(:discourse_activity_pub_log, created_at: 10.days.ago) }
   let!(:log3) { Fabricate(:discourse_activity_pub_log, created_at: 90.days.ago) }
 
-  context "without activity pub enabled" do
-    before { SiteSetting.activity_pub_enabled = false }
-
-    it "does not destroy logs" do
-      expect { described_class.new.execute({}) }.not_to change { DiscourseActivityPubLog.count }
-    end
-  end
-
-  context "with activity pub enabled" do
-    before { SiteSetting.activity_pub_enabled = true }
-
-    it "destroys logs older than activity_pub_logs_max_days_old" do
-      SiteSetting.activity_pub_logs_max_days_old = 7
-      described_class.new.execute({})
-      expect(DiscourseActivityPubLog.exists?(log1.id)).to eq(true)
-      expect(DiscourseActivityPubLog.exists?(log2.id)).to eq(false)
-      expect(DiscourseActivityPubLog.exists?(log3.id)).to eq(false)
-    end
+  it "destroys logs older than activity_pub_logs_max_days_old" do
+    SiteSetting.activity_pub_logs_max_days_old = 7
+    described_class.new.execute({})
+    expect(DiscourseActivityPubLog.exists?(log1.id)).to eq(true)
+    expect(DiscourseActivityPubLog.exists?(log2.id)).to eq(false)
+    expect(DiscourseActivityPubLog.exists?(log3.id)).to eq(false)
   end
 end

--- a/spec/jobs/discourse_activity_pub_log_rotate_spec.rb
+++ b/spec/jobs/discourse_activity_pub_log_rotate_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::DiscourseActivityPubLogRotate do
+  let!(:log1) { Fabricate(:discourse_activity_pub_log, created_at: 1.day.ago) }
+  let!(:log2) { Fabricate(:discourse_activity_pub_log, created_at: 10.days.ago) }
+  let!(:log3) { Fabricate(:discourse_activity_pub_log, created_at: 90.days.ago) }
+
+  context "without activity pub enabled" do
+    before { SiteSetting.activity_pub_enabled = false }
+
+    it "does not destroy logs" do
+      expect { described_class.new.execute({})  }.not_to change {
+        DiscourseActivityPubLog.count
+      }
+    end
+  end
+
+  context "with activity pub enabled" do
+    before { SiteSetting.activity_pub_enabled = true }
+
+    it "destroys logs older than activity_pub_logs_max_days_old" do
+      SiteSetting.activity_pub_logs_max_days_old = 7
+      described_class.new.execute({})
+      expect(DiscourseActivityPubLog.exists?(log1.id)).to eq(true)
+      expect(DiscourseActivityPubLog.exists?(log2.id)).to eq(false)
+      expect(DiscourseActivityPubLog.exists?(log3.id)).to eq(false)
+    end
+  end
+end

--- a/spec/jobs/discourse_activity_pub_log_rotate_spec.rb
+++ b/spec/jobs/discourse_activity_pub_log_rotate_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe Jobs::DiscourseActivityPubLogRotate do
     before { SiteSetting.activity_pub_enabled = false }
 
     it "does not destroy logs" do
-      expect { described_class.new.execute({})  }.not_to change {
-        DiscourseActivityPubLog.count
-      }
+      expect { described_class.new.execute({}) }.not_to change { DiscourseActivityPubLog.count }
     end
   end
 

--- a/spec/requests/discourse_activity_pub/admin/log_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/admin/log_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe DiscourseActivityPub::Admin::LogController do
       expect(response.parsed_body["logs"][0]["id"]).to eq(log2.id)
       expect(response.parsed_body["meta"]["total"]).to eq(2)
       expect(response.parsed_body["meta"]["load_more_url"]).to eq(
-        "/admin/plugins/ap/log.json?offset=1"
+        "/admin/plugins/ap/log.json?offset=1",
       )
 
       get "/admin/plugins/ap/log.json?offset=1"

--- a/spec/requests/discourse_activity_pub/admin/log_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/admin/log_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseActivityPub::Admin::LogController do
+  fab!(:admin)
+
+  it { expect(described_class).to be < DiscourseActivityPub::Admin::AdminController }
+
+  before { sign_in(admin) }
+
+  describe "#index" do
+    let!(:log1) { Fabricate(:discourse_activity_pub_log) }
+    let!(:log2) { Fabricate(:discourse_activity_pub_log) }
+
+    it "returns logs" do
+      get "/admin/plugins/ap/log.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["logs"].size).to eq(2)
+    end
+
+    it "paginates" do
+      DiscourseActivityPub::Admin::LogController.any_instance.stubs(:page_limit).returns(1)
+
+      get "/admin/plugins/ap/log.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["logs"].size).to eq(1)
+      expect(response.parsed_body["logs"][0]["id"]).to eq(log2.id)
+      expect(response.parsed_body["meta"]["total"]).to eq(2)
+      expect(response.parsed_body["meta"]["load_more_url"]).to eq(
+        "/admin/plugins/ap/log.json?offset=1"
+      )
+
+      get "/admin/plugins/ap/log.json?offset=1"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["logs"].size).to eq(1)
+      expect(response.parsed_body["logs"][0]["id"]).to eq(log1.id)
+    end
+  end
+end

--- a/test/javascripts/acceptance/activity-pub-admin-test.js
+++ b/test/javascripts/acceptance/activity-pub-admin-test.js
@@ -11,6 +11,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { default as AdminActors } from "../fixtures/admin-actors-fixtures";
+import { default as Logs } from "../fixtures/logs-fixtures";
 
 const categoryActors =
   AdminActors["/admin/plugins/ap/actor?model_type=category"];
@@ -295,5 +296,48 @@ acceptance("Discourse Activity Pub | Admin | Edit Actor", function (needs) {
     });
 
     await click(".activity-pub-save-actor");
+  });
+});
+
+acceptance("Discourse Activity Pub | Admin | Logs", function (needs) {
+  needs.user({ admin: true });
+  needs.site({
+    activity_pub_enabled: true,
+  });
+  needs.pretender((server, helper) => {
+    server.get("/admin/plugins/ap/log.json", () =>
+      helper.response(Logs["/admin/plugins/ap/log.json"])
+    );
+  });
+
+  test("displays logs", async function (assert) {
+    await visit("/admin/plugins/ap/log");
+
+    assert.ok(exists(".activity-pub-log-table"), "log table is visible");
+    assert.strictEqual(
+      document.querySelectorAll(".activity-pub-log-row").length,
+      2,
+      "logs are visible"
+    );
+    assert.ok(
+      exists(
+        ".activity-pub-log-row:nth-of-type(1) .activity-pub-log-show-json-btn"
+      ),
+      "shows show json button if log has json"
+    );
+    assert.notOk(
+      exists(
+        ".activity-pub-log-row:nth-of-type(2) .activity-pub-log-show-json-btn"
+      ),
+      "does not show json button if log does not have json"
+    );
+
+    await click(
+      ".activity-pub-log-row:nth-of-type(1) .activity-pub-log-show-json-btn"
+    );
+    assert.ok(
+      exists(".modal.activity-pub-json-modal"),
+      "it shows the log json modal"
+    );
   });
 });

--- a/test/javascripts/acceptance/activity-pub-discovery-test.js
+++ b/test/javascripts/acceptance/activity-pub-discovery-test.js
@@ -156,7 +156,7 @@ acceptance(
         "shows the right banner text"
       );
 
-      await triggerEvent(".fk-d-tooltip__trigger", "mousemove");
+      await triggerEvent(".fk-d-tooltip__trigger", "pointermove");
       assert.equal(
         query(".fk-d-tooltip__inner-content").textContent.trim(),
         I18n.t("discourse_activity_pub.banner.public_first_post"),

--- a/test/javascripts/fixtures/logs-fixtures.js
+++ b/test/javascripts/fixtures/logs-fixtures.js
@@ -1,0 +1,110 @@
+export default {
+  "/admin/plugins/ap/log.json": {
+    logs: [
+      {
+        id: 8,
+        created_at: "2025-01-09T13:25:50.558Z",
+        level: "warn",
+        message:
+          "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528 successfully delivered to https://mastodon.pavilion.tech/users/angus/inbox",
+        json: {
+          id: "https://angus.ngrok.io/ap/activity/035bd9c1a837e8204256d7c579697c27",
+          type: "Accept",
+          to: "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528",
+          cc: ["https://www.w3.org/ns/activitystreams#Public"],
+          published: "2025-01-09T13:25:50Z",
+          updated: "2025-01-09T13:25:50Z",
+          actor: {
+            id: "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528",
+            type: "Group",
+            updated: "2025-01-09T13:25:19Z",
+            url: "https://angus.ngrok.io/c/general/4",
+            name: "General",
+            inbox:
+              "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528/inbox",
+            outbox:
+              "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528/outbox",
+            followers:
+              "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528/followers",
+            preferredUsername: "general",
+            publicKey: {
+              id: "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528#main-key",
+              owner:
+                "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528",
+              publicKeyPem:
+                "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAteTuI947KeNVRs62H4Zr\n7mxgu4IrPvTfOCbt8twwgYLTusQGYcYm2FNY0B2aMkztH9RbqJN5tHAoRBPCPuR0\nKYjOtq4M7JTZTGGUmjxVKqXK0Qupp9k1PQUfu5IFeYtw994yyYuo6Q3Q0KyvYZqZ\nUSXmefMEn5IlEbRb/wWt2HV6i/tvAtk4y0i2NhV7ivjPa+L9GvVll1cY4UCHTbx9\n1iqRhx9WsPLmH78Xq45XTLkpG8p99P6PeuinsZpQQaQWlb0cppfJHFyOUY65Sz5h\n2vKA+PEjhXhE1BM8dmSAE9/NyvUWicX5RnGsCH9aKC5TOgYrWAORZDOJwfqQa/jh\n2QIDAQAB\n-----END PUBLIC KEY-----\n",
+            },
+            icon: {
+              type: "Image",
+              mediaType: "image/png",
+              url: "http://localhost:3000/images/discourse-logo-sketch-small.png",
+            },
+            "@context": "https://www.w3.org/ns/activitystreams",
+          },
+          "@context": "https://www.w3.org/ns/activitystreams",
+          object: {
+            id: "https://mastodon.pavilion.tech/5f2aa15f-a480-496c-886c-a3fe1cb268b1",
+            type: "Follow",
+            published: "2025-01-09T13:25:50Z",
+            updated: "2025-01-09T13:25:50Z",
+            actor: {
+              id: "https://mastodon.pavilion.tech/users/angus",
+              type: "Person",
+              updated: "2025-01-09T13:25:43Z",
+              inbox: "https://mastodon.pavilion.tech/users/angus/inbox",
+              outbox: "https://mastodon.pavilion.tech/users/angus/outbox",
+              preferredUsername: "angus",
+              publicKey: {
+                id: "https://mastodon.pavilion.tech/users/angus#main-key",
+                owner: "https://mastodon.pavilion.tech/users/angus",
+                publicKeyPem:
+                  "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA42sRNpIdvRV8x06cWbn+\nGfDTtFl5JuIXkQZfoVEkn22eWwyOMmrHHm1OipL50xQmbrt7iiFcp4QwIh/VeLnF\nyToVXsfrHzI7lLBIGU9cbkPYxm7fdXFynX511EG3xCBhCURhGrnRo20veODz52QE\nMGfyE0IY2BvsnXcplg/fPoZy8Gs0fG0TratxUUAWrOBhUPiDaKjZR5O4qtH+0jzr\nNUC0toRArfAyhmWJ4bvf9DoZoCeAweUGjlTNbWdw/xz11c9YuNu7hWaM3lLn0xIj\nqOYI6uT3eaFbV8xVNYEYk8Gf82jAU3G3PhhjnBYSQQd2ohlGmEqNW7DqXlgY2t1G\nBwIDAQAB\n-----END PUBLIC KEY-----\n",
+              },
+              "@context": "https://www.w3.org/ns/activitystreams",
+            },
+            "@context": "https://www.w3.org/ns/activitystreams",
+            object: {
+              id: "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528",
+              type: "Group",
+              updated: "2025-01-09T13:25:19Z",
+              url: "https://angus.ngrok.io/c/general/4",
+              name: "General",
+              inbox:
+                "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528/inbox",
+              outbox:
+                "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528/outbox",
+              followers:
+                "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528/followers",
+              preferredUsername: "general",
+              publicKey: {
+                id: "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528#main-key",
+                owner:
+                  "https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528",
+                publicKeyPem:
+                  "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAteTuI947KeNVRs62H4Zr\n7mxgu4IrPvTfOCbt8twwgYLTusQGYcYm2FNY0B2aMkztH9RbqJN5tHAoRBPCPuR0\nKYjOtq4M7JTZTGGUmjxVKqXK0Qupp9k1PQUfu5IFeYtw994yyYuo6Q3Q0KyvYZqZ\nUSXmefMEn5IlEbRb/wWt2HV6i/tvAtk4y0i2NhV7ivjPa+L9GvVll1cY4UCHTbx9\n1iqRhx9WsPLmH78Xq45XTLkpG8p99P6PeuinsZpQQaQWlb0cppfJHFyOUY65Sz5h\n2vKA+PEjhXhE1BM8dmSAE9/NyvUWicX5RnGsCH9aKC5TOgYrWAORZDOJwfqQa/jh\n2QIDAQAB\n-----END PUBLIC KEY-----\n",
+              },
+              icon: {
+                type: "Image",
+                mediaType: "image/png",
+                url: "http://localhost:3000/images/discourse-logo-sketch-small.png",
+              },
+              "@context": "https://www.w3.org/ns/activitystreams",
+            },
+          },
+        },
+      },
+      {
+        id: 7,
+        created_at: "2025-01-09T13:25:50.067Z",
+        level: "info",
+        message:
+          "Processing JSON delivered to https://angus.ngrok.io/ap/actor/8f5492e39b0df79f078b659d8d4dc528",
+        json: null,
+      },
+    ],
+    meta: {
+      total: 3,
+      load_more_url: "/admin/plugins/ap/log.json?page=1",
+    },
+  },
+};


### PR DESCRIPTION
@pmusaraj These logs are already available in `/logs` (if the relevant site settings are enabled), however the point here is to make it easer to debug different inter-connectivity scenarios presenting to remote admins. I didn't put this behind site settings, as they are already isolated into a separate table, and there is a rotate (cleanup) job. This is what this looks like:

<img width="1089" alt="Screenshot 2025-01-14 at 15 18 00" src="https://github.com/user-attachments/assets/e6744a47-6fa5-4fd5-ae70-d54fed2dbf54" />
<img width="631" alt="Screenshot 2025-01-14 at 15 17 51" src="https://github.com/user-attachments/assets/a27194dd-a518-4c9a-92f7-1d0f6a506b23" />
