### PR TITLE
DEV: Add Webfinger support to Application Actor

### DIFF
--- a/lib/discourse_activity_pub/webfinger.rb
+++ b/lib/discourse_activity_pub/webfinger.rb
@@ -22,7 +22,10 @@ module DiscourseActivityPub
     end
 
     def permitted_types
-      types = [DiscourseActivityPub::AP::Actor::Group.type, DiscourseActivityPub::AP::Actor::Application.type]
+      types = [
+        DiscourseActivityPub::AP::Actor::Group.type,
+        DiscourseActivityPub::AP::Actor::Application.type,
+      ]
       if DiscourseActivityPub.publishing_enabled
         types << DiscourseActivityPub::AP::Actor::Person.type
       end

--- a/lib/discourse_activity_pub/webfinger.rb
+++ b/lib/discourse_activity_pub/webfinger.rb
@@ -22,7 +22,7 @@ module DiscourseActivityPub
     end
 
     def permitted_types
-      types = [DiscourseActivityPub::AP::Actor::Group.type]
+      types = [DiscourseActivityPub::AP::Actor::Group.type, DiscourseActivityPub::AP::Actor::Application.type]
       if DiscourseActivityPub.publishing_enabled
         types << DiscourseActivityPub::AP::Actor::Person.type
       end

--- a/spec/requests/discourse_activity_pub/webfinger_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/webfinger_controller_spec.rb
@@ -77,6 +77,20 @@ RSpec.describe DiscourseActivityPub::WebfingerController do
             expect(response.parsed_body).to eq(build_error("resource_not_found"))
           end
         end
+
+        context "when requesting an application actor" do
+          let!(:app_actor) { DiscourseActivityPubActor.application }
+
+          it "returns the resource" do
+            get "/.well-known/webfinger?resource=acct:#{app_actor.username}@#{DiscourseActivityPub.host}"
+            expect(response.status).to eq(200)
+
+            body = JSON.parse(response.body)
+            expect(body["subject"]).to eq("acct:#{app_actor.username}@#{DiscourseActivityPub.host}")
+            expect(body["aliases"]).to eq(app_actor.webfinger_aliases)
+            expect(body["links"]).to eq(app_actor.webfinger_links.map(&:as_json))
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This is now required for Mastodon Authorized Fetch. See further:

- https://meta.discourse.org/t/how-to-debug-connectivity-issues-with-activitypub/345798/22?u=angus 
- https://meta.discourse.org/t/activitypub-plugin/266794/394?u=angus

cc @pmusaraj 