### PR TITLE
FIX: handling of AP attributes in topic info modal of first_post topics

### DIFF
--- a/assets/javascripts/discourse/components/activity-pub-attributes.gjs
+++ b/assets/javascripts/discourse/components/activity-pub-attributes.gjs
@@ -16,7 +16,7 @@ export default class ActivityPubAttributes extends Component {
 
   <template>
     <div class="activity-pub-attributes">
-      {{#if this.topic}}
+      {{#if this.topic.activity_pub_object_type}}
         <ActivityPubAttribute
           @attribute="object_type"
           @value={{this.topic.activity_pub_object_type}}

--- a/test/javascripts/acceptance/activity-pub-topic-test.js
+++ b/test/javascripts/acceptance/activity-pub-topic-test.js
@@ -27,7 +27,6 @@ const setupServer = (needs, postAttrs = [], topicAttrs = {}) => {
       post.created_at = createdAt;
       post.activity_pub_enabled = true;
       post.activity_pub_object_type = "Note";
-      post.activity_pub_first_post = true;
       Object.keys(attrs).forEach((attr) => {
         post[attr] = attrs[attr];
       });
@@ -183,7 +182,7 @@ acceptance(
 );
 
 acceptance(
-  "Discourse Activity Pub | Published ActivityPub topic as staff",
+  "Discourse Activity Pub | Published ActivityPub full_topic topic as staff",
   function (needs) {
     needs.user({ moderator: true, admin: false });
     setupServer(
@@ -193,15 +192,20 @@ acceptance(
           activity_pub_published_at: publishedAt,
           activity_pub_visibility: "public",
           activity_pub_local: true,
+          activity_pub_full_topic: true,
         },
         {
           activity_pub_published_at: publishedAt,
           activity_pub_visibility: "public",
           activity_pub_local: true,
+          activity_pub_full_topic: true,
         },
       ],
       {
         activity_pub_published_at: publishedAt,
+        activity_pub_object_type: "Collection",
+        activity_pub_object_id: "https://local.com/collection/1234567",
+        activity_pub_full_topic: true,
       }
     );
 
@@ -296,6 +300,18 @@ acceptance(
         )}.`,
         "shows the right post status text"
       );
+      assert.ok(
+        exists(
+          ".activity-pub-topic-info-modal .activity-pub-attribute.object-type.collection"
+        ),
+        "shows the right topic object type attribute"
+      );
+      assert.ok(
+        exists(
+          ".activity-pub-topic-info-modal .activity-pub-attribute.object-type.note"
+        ),
+        "shows the right post object type attribute"
+      );
     });
 
     test("ActivityPub topic admin modal", async function (assert) {
@@ -357,6 +373,71 @@ acceptance(
         ).innerText.trim(),
         "Public",
         "shows the right visibility text"
+      );
+    });
+  }
+);
+
+acceptance(
+  "Discourse Activity Pub | Published ActivityPub first_post topic as staff",
+  function (needs) {
+    needs.user({ moderator: true, admin: false });
+    setupServer(
+      needs,
+      [
+        {
+          activity_pub_first_post: true,
+          activity_pub_published_at: publishedAt,
+          activity_pub_visibility: "public",
+          activity_pub_local: true,
+        },
+      ],
+      {
+        activity_pub_published_at: publishedAt,
+        activity_pub_full_topic: false,
+      }
+    );
+
+    test("ActivityPub topic info modal", async function (assert) {
+      Site.current().setProperties({
+        activity_pub_enabled: true,
+        activity_pub_publishing_enabled: true,
+      });
+
+      await visit("/t/280");
+
+      await click(".topic-map__activity-pub .activity-pub-topic-status");
+      assert.ok(exists(".activity-pub-topic-info-modal"), "shows the modal");
+
+      assert.strictEqual(
+        query(
+          ".activity-pub-topic-info-modal .activity-pub-topic-status"
+        ).innerText.trim(),
+        `Topic was published on ${publishedAt.format(
+          i18n("dates.long_with_year")
+        )}.`,
+        "shows the right topic status text"
+      );
+      assert.strictEqual(
+        query(
+          ".activity-pub-topic-info-modal .activity-pub-post-status"
+        ).innerText.trim(),
+        `Post was published on ${publishedAt.format(
+          i18n("dates.long_with_year")
+        )}.`,
+        "shows the right post status text"
+      );
+      assert.notOk(
+        exists(
+          ".activity-pub-topic-info-modal .activity-pub-attribute.object-type.collection"
+        ),
+        "does not show a topic object type attribute"
+      );
+      assert.ok(
+        exists(
+          ".activity-pub-topic-info-modal .activity-pub-attribute.object-type.note"
+        ),
+        "shows the right post object type attribute"
       );
     });
   }
@@ -436,6 +517,15 @@ acceptance(
           i18n("dates.long_with_year")
         )}.`,
         "shows the right topic status text"
+      );
+      assert.strictEqual(
+        query(
+          ".activity-pub-topic-info-modal .activity-pub-post-status"
+        ).innerText.trim(),
+        `Post was published on ${publishedAt.format(
+          i18n("dates.long_with_year")
+        )}.`,
+        "shows the right post status text"
       );
       assert.strictEqual(
         query(


### PR DESCRIPTION
@pmusaraj Another small fix from the recent update.

For an example of the issue see:

https://meta.discourse.org/t/postgresql-15-update/349515

<img width="729" alt="Screenshot at Feb 18 09-26-45" src="https://github.com/user-attachments/assets/355cdd55-da27-4046-acb4-08c7714cd56c" />
