### PR TITLE
FIX: Don't show publish all posts when topic is first_post publish type

### DIFF
--- a/assets/javascripts/discourse/components/modal/activity-pub-topic-admin.gjs
+++ b/assets/javascripts/discourse/components/modal/activity-pub-topic-admin.gjs
@@ -51,12 +51,14 @@ export default class ActivityPubTopicAdminModal extends Component {
             <ActivityPubAdminInfo @topic={{this.topic}} @context="topic" />
           </div>
         </div>
-        <div class="control-group">
-          <label>{{i18n "topic.discourse_activity_pub.actions.label"}}</label>
-          <div class="controls">
-            <ActivityPubTopicActions @topic={{this.topic}} />
+        {{#if this.topic.activity_pub_full_topic}}
+          <div class="control-group">
+            <label>{{i18n "topic.discourse_activity_pub.actions.label"}}</label>
+            <div class="controls">
+              <ActivityPubTopicActions @topic={{this.topic}} />
+            </div>
           </div>
-        </div>
+        {{/if}}
         <div class="control-group">
           <label>{{i18n "post.discourse_activity_pub.actions.label"}}</label>
           <div class="controls">

--- a/test/javascripts/acceptance/activity-pub-topic-test.js
+++ b/test/javascripts/acceptance/activity-pub-topic-test.js
@@ -509,6 +509,25 @@ acceptance(
         "shows the right post object type attribute"
       );
     });
+
+    test("ActivityPub topic admin modal", async function (assert) {
+      Site.current().setProperties({
+        activity_pub_enabled: true,
+        activity_pub_publishing_enabled: true,
+        activity_pub_actors: SiteActors,
+      });
+
+      await visit("/t/280");
+      await click(".topic-admin-menu-trigger");
+      await click(".show-activity-pub-topic-admin");
+
+      assert.notOk(
+        query(
+          ".activity-pub-topic-admin-modal .activity-pub-topic-actions .action.publish-all"
+        ),
+        "does not show the publish all posts action"
+      );
+    });
   }
 );
 


### PR DESCRIPTION
https://meta.discourse.org/t/cannot-publish-all-posts-in-some-activitypub-enabled-topics/354237