### PR TITLE
FIX: always prevent AP publishing from a read restricted category

### DIFF
--- a/extensions/discourse_activity_pub_topic_extension.rb
+++ b/extensions/discourse_activity_pub_topic_extension.rb
@@ -11,7 +11,9 @@ module DiscourseActivityPubTopicExtension
   end
 
   def activity_pub_enabled
-    @activity_pub_enabled ||= regular? && activity_pub_taxonomy&.activity_pub_ready?
+    @activity_pub_enabled ||=
+      regular? && activity_pub_taxonomy&.activity_pub_ready? &&
+        (!category || category.activity_pub_allowed?)
   end
 
   def activity_pub_total_posts

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -2459,6 +2459,18 @@ RSpec.describe Post do
               end
             end
           end
+
+          context "in a read restricted category" do
+            before do
+              category.set_permissions(staff: :full)
+              category.save!
+            end
+
+            it "does nothing" do
+              expect(post.perform_activity_pub_activity(:create)).to eq(false)
+              expect(post.reload.activity_pub_object.present?).to eq(false)
+            end
+          end
         end
 
         context "with replies" do


### PR DESCRIPTION
https://meta.discourse.org/t/topic-in-shared-drafts-is-in-a-limbo-publishing-state-for-activitypub/354423/5?u=angus