### PR TITLE
DEV: ensure local actors have a keypair and inbox/outbox

### DIFF
--- a/app/models/discourse_activity_pub_actor.rb
+++ b/app/models/discourse_activity_pub_actor.rb
@@ -275,19 +275,17 @@ class DiscourseActivityPubActor < ActiveRecord::Base
     )
   end
 
-  protected
-
   def ensure_keys
     return unless local? && private_key.blank? && public_key.blank?
 
     keypair = OpenSSL::PKey::RSA.new(2048)
     self.private_key = keypair.to_pem
     self.public_key = keypair.public_key.to_pem
-
-    save!
   end
 
   def ensure_inbox_and_outbox
+    return unless local?
+
     self.inbox = "#{self.ap_id}/inbox" if !self.inbox
     self.outbox = "#{self.ap_id}/outbox" if !self.outbox
   end

--- a/lib/discourse_activity_pub/actor_handler.rb
+++ b/lib/discourse_activity_pub/actor_handler.rb
@@ -66,6 +66,8 @@ module DiscourseActivityPub
           update_actor_from_model
         end
 
+        ensure_required_attributes
+
         actor.save! if actor.new_record? || actor.changed?
       end
 
@@ -159,6 +161,12 @@ module DiscourseActivityPub
 
       actor.username = username
       actor.name = model.activity_pub_name if model.activity_pub_name
+    end
+
+    def ensure_required_attributes
+      return unless actor.local?
+      actor.ensure_keys
+      actor.ensure_inbox_and_outbox
     end
 
     def update_actor_from_opts

--- a/spec/lib/discourse_activity_pub/actor_handler_spec.rb
+++ b/spec/lib/discourse_activity_pub/actor_handler_spec.rb
@@ -162,8 +162,8 @@ RSpec.describe DiscourseActivityPub::ActorHandler do
         expect(actor.reload.model_id).to eq(user.id)
       end
 
-      context "with an actor" do
-        let!(:actor) { Fabricate(:discourse_activity_pub_actor_person, model: user) }
+      context "with a local actor" do
+        let!(:actor) { Fabricate(:discourse_activity_pub_actor_person, model: user, local: true) }
 
         it "returns the actor" do
           actor = described_class.update_or_create_actor(user)
@@ -174,6 +174,17 @@ RSpec.describe DiscourseActivityPub::ActorHandler do
           actor_count = DiscourseActivityPubActor.all.size
           described_class.update_or_create_actor(user)
           expect(DiscourseActivityPubActor.all.size).to eq(actor_count)
+        end
+
+        context "when required attributes are blank" do
+          before { actor.update(public_key: nil, private_key: nil, inbox: nil, outbox: nil) }
+
+          it "ensures they are set" do
+            described_class.update_or_create_actor(user)
+            expect(actor.reload.keypair).to be_present
+            expect(actor.inbox).to be_present
+            expect(actor.outbox).to be_present
+          end
         end
       end
 

--- a/spec/models/discourse_activity_pub_actor_spec.rb
+++ b/spec/models/discourse_activity_pub_actor_spec.rb
@@ -114,6 +114,21 @@ RSpec.describe DiscourseActivityPubActor do
         }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
+
+    it "sets required attributes for local actors" do
+      user = Fabricate(:user)
+      actor =
+        described_class.create!(
+          local: true,
+          model_id: user.id,
+          model_type: user.class.name,
+          ap_type: DiscourseActivityPub::AP::Actor::Person.type,
+          username: user.username,
+        )
+      expect(actor.keypair).to be_present
+      expect(actor.inbox).to be_present
+      expect(actor.outbox).to be_present
+    end
   end
 
   describe "#find_by_handle" do


### PR DESCRIPTION
See further: https://meta.discourse.org/t/local-activitypub-actors-are-being-created-without-keypairs/356834