### PR TITLE
FIX: incorrect actor attributes

### DIFF
--- a/app/models/discourse_activity_pub_actor.rb
+++ b/app/models/discourse_activity_pub_actor.rb
@@ -286,8 +286,8 @@ class DiscourseActivityPubActor < ActiveRecord::Base
   def ensure_inbox_and_outbox
     return unless local?
 
-    self.inbox = "#{self.ap_id}/inbox" if !self.inbox
-    self.outbox = "#{self.ap_id}/outbox" if !self.outbox
+    self.inbox = "#{self.ap_id}/inbox" if !self.inbox || self.inbox.exclude?(self.ap_key)
+    self.outbox = "#{self.ap_id}/outbox" if !self.outbox || self.outbox.exclude?(self.ap_key)
   end
 
   def local_username_uniqueness

--- a/lib/discourse_activity_pub/actor_handler.rb
+++ b/lib/discourse_activity_pub/actor_handler.rb
@@ -165,6 +165,10 @@ module DiscourseActivityPub
 
     def ensure_required_attributes
       return unless actor.local?
+
+      actor.ensure_ap_type
+      actor.ensure_ap_key
+      actor.ensure_ap_id
       actor.ensure_keys
       actor.ensure_inbox_and_outbox
     end

--- a/lib/discourse_activity_pub/actor_handler.rb
+++ b/lib/discourse_activity_pub/actor_handler.rb
@@ -166,6 +166,8 @@ module DiscourseActivityPub
     def ensure_required_attributes
       return unless actor.local?
 
+      # Normally these are set in model callbacks when an actor is created, however
+      # those callbacks fail for some user actors making this fallback necessary.
       actor.ensure_ap_type
       actor.ensure_ap_key
       actor.ensure_ap_id

--- a/spec/lib/discourse_activity_pub/actor_handler_spec.rb
+++ b/spec/lib/discourse_activity_pub/actor_handler_spec.rb
@@ -181,9 +181,18 @@ RSpec.describe DiscourseActivityPub::ActorHandler do
 
           it "ensures they are set" do
             described_class.update_or_create_actor(user)
-            expect(actor.reload.keypair).to be_present
-            expect(actor.inbox).to be_present
-            expect(actor.outbox).to be_present
+            expect(actor.reload.ap_key).to be_present
+            expect(actor.ap_id).to be_present
+            expect(actor.inbox).to eq("#{actor.ap_id}/inbox")
+            expect(actor.outbox).to eq("#{actor.ap_id}/outbox")
+            expect(actor.keypair).to be_present
+          end
+
+          it "ensures inbox and outbox urls have the correct structure" do
+            actor.update(inbox: "/inbox", outbox: "/outbox")
+            described_class.update_or_create_actor(user)
+            expect(actor.inbox).to eq("#{actor.ap_id}/inbox")
+            expect(actor.outbox).to eq("#{actor.ap_id}/outbox")
           end
         end
       end


### PR DESCRIPTION
@pmusaraj https://github.com/discourse/discourse-activity-pub/pull/188 introduced a bug resulting in https://meta.discourse.org/t/follow-requests-not-accepted/357299

1. I considered added a db migration to this, however [the issue](https://meta.discourse.org/t/local-activitypub-actors-are-being-created-without-keypairs/356834) the original PR was addressing in the first place was a data anomaly, i.e. it shouldn't have been possible to begin with, so a db migration would not be sufficient.

2. More broadly, one of the things that seems to hold in ActivityPub is that you need ongoing data integrity checks, regardless of data ownership.