### PR TITLE
FEATURE: Add support for processing incoming attachments

### DIFF
--- a/app/models/concerns/discourse_activity_pub/ap/identifier_validations.rb
+++ b/app/models/concerns/discourse_activity_pub/ap/identifier_validations.rb
@@ -4,19 +4,14 @@ module DiscourseActivityPub
     module IdentifierValidations
       extend ActiveSupport::Concern
       include JsonLd
+      include TypeValidations
 
       included do
-        before_validation :ensure_ap_type
         before_validation :ensure_ap_key, if: :local?
         before_validation :ensure_ap_id, if: :local?
 
-        validates :ap_type, presence: true
         validates :ap_key, uniqueness: true, allow_nil: true # foreign objects don't have keys
         validates :ap_id, uniqueness: true, presence: true
-      end
-
-      def ap
-        @ap ||= DiscourseActivityPub::AP::Object.get_klass(ap_type)&.new(stored: self)
       end
 
       def local?
@@ -25,27 +20,6 @@ module DiscourseActivityPub
 
       def remote?
         !local?
-      end
-
-      def _model
-        self.respond_to?(:model) ? self.model : self.actor.model
-      end
-
-      def ensure_ap_type
-        self.ap_type = _model.activity_pub_default_object_type if !self.ap_type
-
-        unless ap
-          self.errors.add(
-            :ap_type,
-            I18n.t(
-              "activerecord.errors.models.discourse_activity_pub_activity.attributes.ap_type.invalid",
-            ),
-          )
-
-          raise ActiveRecord::RecordInvalid
-        end
-
-        self.ap_type = ap.type
       end
 
       def ensure_ap_key

--- a/app/models/concerns/discourse_activity_pub/ap/type_validations.rb
+++ b/app/models/concerns/discourse_activity_pub/ap/type_validations.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module DiscourseActivityPub
+  module AP
+    module TypeValidations
+      extend ActiveSupport::Concern
+
+      included do
+        before_validation :ensure_ap_type
+        validates :ap_type, presence: true
+      end
+
+      def ap
+        @ap ||= DiscourseActivityPub::AP::Object.get_klass(ap_type)&.new(stored: self)
+      end
+
+      def _model
+        self.respond_to?(:model) ? self.model : self.actor.model
+      end
+
+      def ensure_ap_type
+        self.ap_type = _model.activity_pub_default_object_type if !self.ap_type && _model.present?
+
+        unless ap
+          self.errors.add(
+            :ap_type,
+            I18n.t(
+              "activerecord.errors.models.discourse_activity_pub_activity.attributes.ap_type.invalid",
+            ),
+          )
+
+          raise ActiveRecord::RecordInvalid
+        end
+
+        self.ap_type = ap.type
+      end
+    end
+  end
+end

--- a/app/models/discourse_activity_pub_attachment.rb
+++ b/app/models/discourse_activity_pub_attachment.rb
@@ -31,11 +31,9 @@ end
 #  ap_type     :string           not null
 #  object_id   :bigint           not null
 #  object_type :string           not null
-#  model_id    :integer
-#  model_type  :string
 #  url         :string
 #  name        :string
-#  media_type  :string
+#  media_type  :string(200)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/app/models/discourse_activity_pub_attachment.rb
+++ b/app/models/discourse_activity_pub_attachment.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class DiscourseActivityPubAttachment < ActiveRecord::Base
+  include DiscourseActivityPub::AP::TypeValidations
+  include DiscourseActivityPub::AP::ObjectValidations
+
+  belongs_to :object, class_name: "DiscourseActivityPubObject", polymorphic: true
+
+  validate :validate_media_type
+
+  protected
+
+  def validate_media_type
+    unless MiniMime.lookup_by_content_type(self.media_type)
+      self.errors.add(
+        :media_type,
+        I18n.t(
+          "activerecord.errors.models.discourse_activity_pub_attachment.attributes.media_type.invalid",
+        ),
+      )
+      raise ActiveRecord::RecordInvalid
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: discourse_activity_pub_attachments
+#
+#  id          :bigint           not null, primary key
+#  ap_type     :string           not null
+#  object_id   :bigint           not null
+#  object_type :string           not null
+#  model_id    :integer
+#  model_type  :string
+#  url         :string
+#  name        :string
+#  media_type  :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#

--- a/app/models/discourse_activity_pub_object.rb
+++ b/app/models/discourse_activity_pub_object.rb
@@ -7,12 +7,21 @@ class DiscourseActivityPubObject < ActiveRecord::Base
 
   belongs_to :model, -> { unscope(where: :deleted_at) }, polymorphic: true, optional: true
   belongs_to :collection, class_name: "DiscourseActivityPubCollection", foreign_key: "collection_id"
+  belongs_to :reply_to,
+             class_name: "DiscourseActivityPubObject",
+             primary_key: "ap_id",
+             foreign_key: "reply_to_id"
+  belongs_to :attributed_to,
+             class_name: "DiscourseActivityPubActor",
+             primary_key: "ap_id",
+             foreign_key: "attributed_to_id"
 
-  has_many :activities, class_name: "DiscourseActivityPubActivity", foreign_key: "object_id"
   has_one :create_activity,
           -> { where(ap_type: DiscourseActivityPub::AP::Activity::Create.type) },
           class_name: "DiscourseActivityPubActivity",
           foreign_key: "object_id"
+
+  has_many :activities, class_name: "DiscourseActivityPubActivity", foreign_key: "object_id"
   has_many :announcements,
            class_name: "DiscourseActivityPubActivity",
            through: :activities,
@@ -21,20 +30,11 @@ class DiscourseActivityPubObject < ActiveRecord::Base
            -> { likes },
            class_name: "DiscourseActivityPubActivity",
            foreign_key: "object_id"
-
-  belongs_to :reply_to,
-             class_name: "DiscourseActivityPubObject",
-             primary_key: "ap_id",
-             foreign_key: "reply_to_id"
   has_many :replies,
            class_name: "DiscourseActivityPubObject",
            primary_key: "ap_id",
            foreign_key: "reply_to_id"
-
-  belongs_to :attributed_to,
-             class_name: "DiscourseActivityPubActor",
-             primary_key: "ap_id",
-             foreign_key: "attributed_to_id"
+  has_many :attachments, class_name: "DiscourseActivityPubAttachment", foreign_key: "object_id"
 
   def url
     if local?

--- a/app/serializers/discourse_activity_pub/ap/object_serializer.rb
+++ b/app/serializers/discourse_activity_pub/ap/object_serializer.rb
@@ -20,8 +20,8 @@ class DiscourseActivityPub::AP::ObjectSerializer < ActiveModel::Serializer
     hash
   end
 
-  def context
-    object.context
+  def include_id?
+    object.id.present?
   end
 
   def include_context?

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -21,6 +21,10 @@ en:
             credentials:
               required: "are required"
               invalid: "is not valid"
+        discourse_activity_pub_attachment:
+          attributes:
+            media_type:
+              invalid: "is not valid"
         discourse_activity_pub:
           attributes:
             model_type:

--- a/db/migrate/20250319134150_create_discourse_activity_pub_attachments.rb
+++ b/db/migrate/20250319134150_create_discourse_activity_pub_attachments.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class CreateDiscourseActivityPubAttachments < ActiveRecord::Migration[7.2]
+  def change
+    create_table :discourse_activity_pub_attachments do |t|
+      t.string :ap_type, null: false
+      t.bigint :object_id, null: false
+      t.string :object_type, null: false
+      t.string :url
+      t.string :name
+      t.string :media_type, limit: 200
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/discourse_activity_pub/ap/object/document.rb
+++ b/lib/discourse_activity_pub/ap/object/document.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module DiscourseActivityPub
+  module AP
+    class Object
+      class Document < Object
+        def type
+          "Document"
+        end
+
+        def can_belong_to
+          %i[remote]
+        end
+      end
+    end
+  end
+end

--- a/lib/discourse_activity_pub/ap/object/image.rb
+++ b/lib/discourse_activity_pub/ap/object/image.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module DiscourseActivityPub
+  module AP
+    class Object
+      class Image < Object
+        def type
+          "Image"
+        end
+
+        def can_belong_to
+          %i[remote]
+        end
+      end
+    end
+  end
+end

--- a/lib/discourse_activity_pub/post_handler.rb
+++ b/lib/discourse_activity_pub/post_handler.rb
@@ -31,7 +31,7 @@ module DiscourseActivityPub
       return nil if !import_mode && !new_topic && !reply_to && !topic_id
 
       params = {
-        raw: object.content,
+        raw: build_post_raw,
         skip_events: true,
         skip_validations: true,
         skip_jobs: true,
@@ -148,6 +148,21 @@ module DiscourseActivityPub
     end
 
     protected
+
+    def supported_media_type?(media_type)
+      extension = MiniMime.lookup_by_content_type(media_type)&.extension
+      FileHelper.supported_images.include?(extension)
+    end
+
+    def build_post_raw
+      raw = object.content
+      if object.attachments.present?
+        object.attachments.each do |attachment|
+          raw += "\n#{attachment.url}" if supported_media_type?(attachment.media_type)
+        end
+      end
+      raw
+    end
 
     def can_create_topic?(category)
       category&.activity_pub_ready?

--- a/lib/discourse_activity_pub/post_handler.rb
+++ b/lib/discourse_activity_pub/post_handler.rb
@@ -149,7 +149,7 @@ module DiscourseActivityPub
 
     protected
 
-    def supported_media_type?(media_type)
+    def supported_image?(media_type)
       extension = MiniMime.lookup_by_content_type(media_type)&.extension
       FileHelper.supported_images.include?(extension)
     end
@@ -158,10 +158,14 @@ module DiscourseActivityPub
       raw = object.content
       if object.attachments.present?
         object.attachments.each do |attachment|
-          raw += "\n#{attachment.url}" if supported_media_type?(attachment.media_type)
+          raw += attached_image_html(attachment) if supported_image?(attachment.media_type)
         end
       end
       raw
+    end
+
+    def attached_image_html(attachment)
+      "\n<img src=\"#{attachment.url}\" alt=\"#{attachment.name}\"/>"
     end
 
     def can_create_topic?(category)

--- a/plugin.rb
+++ b/plugin.rb
@@ -67,11 +67,14 @@ after_initialize do
   require_relative "lib/discourse_activity_pub/ap/activity/like"
   require_relative "lib/discourse_activity_pub/ap/object/note"
   require_relative "lib/discourse_activity_pub/ap/object/article"
+  require_relative "lib/discourse_activity_pub/ap/object/document"
+  require_relative "lib/discourse_activity_pub/ap/object/image"
   require_relative "lib/discourse_activity_pub/ap/collection"
   require_relative "lib/discourse_activity_pub/ap/collection/collection_page"
   require_relative "lib/discourse_activity_pub/ap/collection/ordered_collection_page"
   require_relative "lib/discourse_activity_pub/ap/collection/ordered_collection"
   require_relative "lib/discourse_activity_pub/admin"
+  require_relative "app/models/concerns/discourse_activity_pub/ap/type_validations"
   require_relative "app/models/concerns/discourse_activity_pub/ap/identifier_validations"
   require_relative "app/models/concerns/discourse_activity_pub/ap/object_validations"
   require_relative "app/models/concerns/discourse_activity_pub/ap/model_validations"
@@ -87,6 +90,7 @@ after_initialize do
   require_relative "app/models/discourse_activity_pub_log"
   require_relative "app/models/discourse_activity_pub_object"
   require_relative "app/models/discourse_activity_pub_collection"
+  require_relative "app/models/discourse_activity_pub_attachment"
   require_relative "app/jobs/discourse_activity_pub_process"
   require_relative "app/jobs/discourse_activity_pub_deliver"
   require_relative "app/jobs/discourse_activity_pub_log_rotate"
@@ -1158,6 +1162,23 @@ after_initialize do
                     "discourse_activity_pub.process.error.failed_to_save_object",
                     object_id: object.json[:id],
                   )
+          end
+
+          if object.json[:attachment].present?
+            object.json[:attachment].each do |attachment|
+              begin
+                DiscourseActivityPubAttachment.create(
+                  object_id: object.stored.id,
+                  object_type: "DiscourseActivityPubObject",
+                  ap_type: attachment[:type],
+                  url: attachment[:url],
+                  name: attachment[:name],
+                  media_type: attachment[:mediaType],
+                )
+              rescue ActiveRecord::RecordInvalid => error
+                # fail silently if an attachment does not validate
+              end
+            end
           end
         end
       end

--- a/spec/lib/discourse_activity_pub/ap/activity/create_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/create_spec.rb
@@ -470,7 +470,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
                 build_object_json(
                   name: "My cool topic title",
                   attributed_to: actor,
-                  attachment: attachments_with_supported_mediatypes,
+                  attachments: attachments_with_supported_mediatypes,
                 ),
               type: "Create",
             )
@@ -508,7 +508,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
                 build_object_json(
                   name: "My cool topic title",
                   attributed_to: actor,
-                  attachment: attachments_with_unsupported_mediatypes,
+                  attachments: attachments_with_unsupported_mediatypes,
                 ),
               type: "Create",
             )
@@ -542,7 +542,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
                 build_object_json(
                   name: "My cool topic title",
                   attributed_to: actor,
-                  attachment: attachments_with_invalid_mediatypes,
+                  attachments: attachments_with_invalid_mediatypes,
                 ),
               type: "Create",
             )
@@ -571,7 +571,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
           build_object_json(
             name: "My cool topic title",
             attributed_to: actor,
-            attachment: [
+            attachments: [
               { type: "PropertyValue", name: "Homepage", value: "https://myhomepage.com" },
             ],
           )

--- a/spec/lib/discourse_activity_pub/ap/activity/create_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/create_spec.rb
@@ -426,5 +426,175 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
         end
       end
     end
+
+    context "with a Note with attachments" do
+      let!(:delivered_to) { category.activity_pub_actor.ap_id }
+      let!(:follow) do
+        Fabricate(
+          :discourse_activity_pub_follow,
+          follower: category.activity_pub_actor,
+          followed: actor,
+        )
+      end
+
+      before { stub_object_request(actor) }
+
+      context "with supported attachment types" do
+        let!(:attachment_url_1) { "https://example.com/files/cats.png" }
+        let!(:attachment_url_2) { "https://example.com/files/dogs.jpeg" }
+        let!(:attachment_url_3) { "https://example.com/files/autodesk-dog.3ds" }
+        let!(:attachments_with_supported_mediatypes) do
+          [
+            { type: "Document", mediaType: "image/png", url: attachment_url_1 },
+            { type: "Image", mediaType: "image/jpeg", url: attachment_url_2 },
+          ]
+        end
+        let!(:attachments_with_unsupported_mediatypes) do
+          [
+            { type: "Document", mediaType: "image/png", url: attachment_url_1 },
+            { type: "Image", mediaType: "image/x-3ds", url: attachment_url_3 },
+          ]
+        end
+        let!(:attachments_with_invalid_mediatypes) do
+          [
+            { type: "Document", mediaType: "image/png", url: attachment_url_1 },
+            { type: "Image", mediaType: "invalid-type", url: attachment_url_3 },
+          ]
+        end
+
+        context "with supported media types" do
+          let!(:new_post_json) do
+            build_activity_json(
+              actor: actor,
+              object:
+                build_object_json(
+                  name: "My cool topic title",
+                  attributed_to: actor,
+                  attachment: attachments_with_supported_mediatypes,
+                ),
+              type: "Create",
+            )
+          end
+
+          it "creates records for all attachments" do
+            perform_process(new_post_json, delivered_to)
+            object =
+              DiscourseActivityPubObject.find_by(ap_type: "Note", attributed_to_id: actor.ap_id)
+            expect(object.attachments.size).to eq(2)
+            expect(object.attachments.first.ap_type).to eq("Document")
+            expect(object.attachments.first.url).to eq(attachment_url_1)
+            expect(object.attachments.first.media_type).to eq("image/png")
+            expect(object.attachments.second.ap_type).to eq("Image")
+            expect(object.attachments.second.url).to eq(attachment_url_2)
+            expect(object.attachments.second.media_type).to eq("image/jpeg")
+          end
+
+          it "adds the attachment urls the post" do
+            perform_process(new_post_json, delivered_to)
+            post =
+              Post.find_by(
+                raw:
+                  "#{new_post_json[:object][:content]}\n#{attachment_url_1}\n#{attachment_url_2}",
+              )
+            expect(post.present?).to be(true)
+          end
+        end
+
+        context "with supported and unsupported media types" do
+          let!(:new_post_json) do
+            build_activity_json(
+              actor: actor,
+              object:
+                build_object_json(
+                  name: "My cool topic title",
+                  attributed_to: actor,
+                  attachment: attachments_with_unsupported_mediatypes,
+                ),
+              type: "Create",
+            )
+          end
+
+          it "creates records for all attachments" do
+            perform_process(new_post_json, delivered_to)
+            object =
+              DiscourseActivityPubObject.find_by(ap_type: "Note", attributed_to_id: actor.ap_id)
+            expect(object.attachments.size).to eq(2)
+            expect(object.attachments.first.ap_type).to eq("Document")
+            expect(object.attachments.first.url).to eq(attachment_url_1)
+            expect(object.attachments.first.media_type).to eq("image/png")
+            expect(object.attachments.second.ap_type).to eq("Image")
+            expect(object.attachments.second.url).to eq(attachment_url_3)
+            expect(object.attachments.second.media_type).to eq("image/x-3ds")
+          end
+
+          it "adds urls for attachments with supported media types to the post" do
+            perform_process(new_post_json, delivered_to)
+            post = Post.find_by(raw: "#{new_post_json[:object][:content]}\n#{attachment_url_1}")
+            expect(post.present?).to be(true)
+          end
+        end
+
+        context "with supported and invalid media types" do
+          let!(:new_post_json) do
+            build_activity_json(
+              actor: actor,
+              object:
+                build_object_json(
+                  name: "My cool topic title",
+                  attributed_to: actor,
+                  attachment: attachments_with_invalid_mediatypes,
+                ),
+              type: "Create",
+            )
+          end
+
+          it "creates records for attachments with valid media types" do
+            perform_process(new_post_json, delivered_to)
+            object =
+              DiscourseActivityPubObject.find_by(ap_type: "Note", attributed_to_id: actor.ap_id)
+            expect(object.attachments.size).to eq(1)
+            expect(object.attachments.first.ap_type).to eq("Document")
+            expect(object.attachments.first.url).to eq(attachment_url_1)
+            expect(object.attachments.first.media_type).to eq("image/png")
+          end
+
+          it "adds urls for attachments with supported media types to the post" do
+            perform_process(new_post_json, delivered_to)
+            post = Post.find_by(raw: "#{new_post_json[:object][:content]}\n#{attachment_url_1}")
+            expect(post.present?).to be(true)
+          end
+        end
+      end
+
+      context "with unsupported attachment types" do
+        let!(:object_with_unsupported_attachment_json) do
+          build_object_json(
+            name: "My cool topic title",
+            attributed_to: actor,
+            attachment: [
+              { type: "PropertyValue", name: "Homepage", value: "https://myhomepage.com" },
+            ],
+          )
+        end
+        let!(:new_post_json) do
+          build_activity_json(
+            actor: actor,
+            object: object_with_unsupported_attachment_json,
+            type: "Create",
+          )
+        end
+
+        it "does not create attachments" do
+          expect { perform_process(new_post_json, delivered_to) }.not_to change {
+            DiscourseActivityPubAttachment.count
+          }
+        end
+
+        it "does not add anything to the post" do
+          perform_process(new_post_json, delivered_to)
+          expect(Post.exists?(raw: new_post_json[:object][:content])).to be(true)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/discourse_activity_pub/ap/activity/create_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/create_spec.rb
@@ -443,21 +443,37 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
         let!(:attachment_url_1) { "https://example.com/files/cats.png" }
         let!(:attachment_url_2) { "https://example.com/files/dogs.jpeg" }
         let!(:attachment_url_3) { "https://example.com/files/autodesk-dog.3ds" }
+        let!(:attachment_name_1) { "A cool cat" }
         let!(:attachments_with_supported_mediatypes) do
           [
-            { type: "Document", mediaType: "image/png", url: attachment_url_1 },
+            {
+              type: "Document",
+              mediaType: "image/png",
+              url: attachment_url_1,
+              name: attachment_name_1,
+            },
             { type: "Image", mediaType: "image/jpeg", url: attachment_url_2 },
           ]
         end
         let!(:attachments_with_unsupported_mediatypes) do
           [
-            { type: "Document", mediaType: "image/png", url: attachment_url_1 },
+            {
+              type: "Document",
+              mediaType: "image/png",
+              url: attachment_url_1,
+              name: attachment_name_1,
+            },
             { type: "Image", mediaType: "image/x-3ds", url: attachment_url_3 },
           ]
         end
         let!(:attachments_with_invalid_mediatypes) do
           [
-            { type: "Document", mediaType: "image/png", url: attachment_url_1 },
+            {
+              type: "Document",
+              mediaType: "image/png",
+              url: attachment_url_1,
+              name: attachment_name_1,
+            },
             { type: "Image", mediaType: "invalid-type", url: attachment_url_3 },
           ]
         end
@@ -494,7 +510,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
             post =
               Post.find_by(
                 raw:
-                  "#{new_post_json[:object][:content]}\n#{attachment_url_1}\n#{attachment_url_2}",
+                  "#{new_post_json[:object][:content]}\n<img src=\"#{attachment_url_1}\" alt=\"#{attachment_name_1}\"/>\n<img src=\"#{attachment_url_2}\" alt=\"\"/>",
               )
             expect(post.present?).to be(true)
           end
@@ -529,7 +545,11 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
 
           it "adds urls for attachments with supported media types to the post" do
             perform_process(new_post_json, delivered_to)
-            post = Post.find_by(raw: "#{new_post_json[:object][:content]}\n#{attachment_url_1}")
+            post =
+              Post.find_by(
+                raw:
+                  "#{new_post_json[:object][:content]}\n<img src=\"#{attachment_url_1}\" alt=\"#{attachment_name_1}\"/>",
+              )
             expect(post.present?).to be(true)
           end
         end
@@ -560,7 +580,11 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Create do
 
           it "adds urls for attachments with supported media types to the post" do
             perform_process(new_post_json, delivered_to)
-            post = Post.find_by(raw: "#{new_post_json[:object][:content]}\n#{attachment_url_1}")
+            post =
+              Post.find_by(
+                raw:
+                  "#{new_post_json[:object][:content]}\n<img src=\"#{attachment_url_1}\" alt=\"#{attachment_name_1}\"/>",
+              )
             expect(post.present?).to be(true)
           end
         end

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -150,7 +150,8 @@ def build_object_json(
   cc: nil,
   audience: nil,
   attributed_to: nil,
-  context: nil
+  context: nil,
+  attachments: []
 )
   _json = {
     "@context": "https://www.w3.org/ns/activitystreams",
@@ -173,6 +174,7 @@ def build_object_json(
     attributed_to
   end
   _json[:context] = context if context
+  _json[:attachments] = attachments if attachments.present?
   _json
 end
 

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -174,7 +174,7 @@ def build_object_json(
     attributed_to
   end
   _json[:context] = context if context
-  _json[:attachments] = attachments if attachments.present?
+  _json[:attachment] = attachments if attachments.present?
   _json
 end
 


### PR DESCRIPTION
@pmusaraj This adds support for processing inbound attachments, and adding supported image attachments to posts in the simplest way possible. This is the first step in adding media support. We can merge this in now as a contained feature, or we can wait until outbound support is included too. I thought it might be nice to split it up to make it easier to review. This will work as-is.