### PR TITLE
FIX: Pre-emptively destroy Follow on Reject

### DIFF
--- a/lib/discourse_activity_pub/follow_handler.rb
+++ b/lib/discourse_activity_pub/follow_handler.rb
@@ -33,7 +33,8 @@ module DiscourseActivityPub
       return false unless reject_object
       return false unless reject_activity
 
-      # The follow itself is destroyed in DiscourseActivityPubActivity.after_deliver
+      # Destroy follow on reject, regardless of whether delivery succeeds.
+      destroy_follow
 
       deliver(reject_activity)
     end
@@ -124,6 +125,13 @@ module DiscourseActivityPub
         object: object,
         recipient_ids: [target_actor.id],
       )
+    end
+
+    def destroy_follow
+      DiscourseActivityPubFollow.where(
+        follower_id: target_actor.id,
+        followed_id: actor.id,
+      ).destroy_all
     end
   end
 end

--- a/spec/lib/discourse_activity_pub/follow_handler_spec.rb
+++ b/spec/lib/discourse_activity_pub/follow_handler_spec.rb
@@ -199,8 +199,9 @@ RSpec.describe DiscourseActivityPub::FollowHandler do
             perform(actor.id, target_actor.id)
           end
 
-          it "doesn't destroy the follow" do
-            expect(follow.destroyed?).to eq(false)
+          it "destroys the follow" do
+            perform(actor.id, target_actor.id)
+            expect(DiscourseActivityPubFollow.exists?(follow.id)).to eq(false)
           end
         end
 


### PR DESCRIPTION
Follow will be destroyed regardless of whether delivery of Reject to the remote Actor succeeds.