### PR TITLE
FIX: Allow topic title editing for non-ActivityPub posts

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -361,7 +361,8 @@ after_initialize do
     end
   end
   on(:post_edited) do |post, topic_changed, post_revisor|
-    if post.activity_pub_full_topic && post_revisor.topic_title_changed?
+    if post.activity_pub_full_topic && post_revisor.topic_title_changed? &&
+         post.topic.activity_pub_object
       post.topic.activity_pub_object.name = post.topic.activity_pub_name
       post.topic.activity_pub_object.save!
     end

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -140,5 +140,15 @@ RSpec.describe PostRevisor do
         end
       end
     end
+
+    context "when revising a non-activity-pub post" do
+      context "with full_topic enabled" do
+        before { toggle_activity_pub(category, publication_type: "full_topic") }
+        it "allows updating the topic title" do
+          new_title = "New topic title"
+          expect { post_revisor.revise!(user, title: new_title) }.not_to raise_error
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes an edge case where updating the topic title of a non-ActivityPub post would raise an error when making the edit via the OP's composer.