### PR TITLE
FIX: Use correct page for load_more_uri

### DIFF
--- a/app/controllers/discourse_activity_pub/actor_controller.rb
+++ b/app/controllers/discourse_activity_pub/actor_controller.rb
@@ -168,7 +168,7 @@ module DiscourseActivityPub
     def load_more_url(page)
       load_more_params = params.slice(:order, :asc).permit!
       load_more_params[:page] = page + 1
-      load_more_uri = ::URI.parse("/ap/actor/#{params[:actor_id]}/followers.json")
+      load_more_uri = ::URI.parse("/ap/local/actor/#{params[:actor_id]}/#{action_name}.json")
       load_more_uri.query = ::URI.encode_www_form(load_more_params.to_h)
       load_more_uri.to_s
     end

--- a/spec/requests/discourse_activity_pub/actor_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/actor_controller_spec.rb
@@ -130,6 +130,9 @@ RSpec.describe DiscourseActivityPub::ActorController do
           get "/ap/local/actor/#{actor1.id}/follows.json?limit=1&page=1"
           expect(response.status).to eq(200)
           expect(response.parsed_body["actors"].map { |f| f["url"] }).to eq([follower2.ap_id])
+          expect(response.parsed_body["meta"]["load_more_url"]).to eq(
+            "/ap/local/actor/#{actor1.id}/follows.json?page=2",
+          )
         end
 
         context "with publishing disabled" do
@@ -187,6 +190,9 @@ RSpec.describe DiscourseActivityPub::ActorController do
           get "/ap/local/actor/#{actor1.id}/followers.json?limit=2&page=1"
           expect(response.status).to eq(200)
           expect(response.parsed_body["actors"].map { |f| f["url"] }).to eq([follower1.ap_id])
+          expect(response.parsed_body["meta"]["load_more_url"]).to eq(
+            "/ap/local/actor/#{actor1.id}/followers.json?page=2",
+          )
         end
 
         context "with publishing disabled" do


### PR DESCRIPTION
Should fix an issue with pagination on actors with more than 50 follows/followers: 

<img width="2236" height="922" alt="CleanShot 2025-08-15 at 13 42 03@2x" src="https://github.com/user-attachments/assets/431ecdae-7a7c-4e97-8ef9-07f9ebd2450c" />
