### PR TITLE
DEV: Ensure activity_pub_published_at returns a single date

### DIFF
--- a/app/models/discourse_activity_pub/post.rb
+++ b/app/models/discourse_activity_pub/post.rb
@@ -101,6 +101,12 @@ module DiscourseActivityPub::Post
     end
   end
 
+  def activity_pub_published_at
+    # We have to do this because sometimes we store multiple published_at timestamps
+    # TODO: figure out what causes us to store multiples of this custom field
+    Array(custom_fields["activity_pub_published_at"]).first
+  end
+
   def activity_pub_actor
     return @activity_pub_actor if !@activity_pub_actor.nil?
     return nil unless activity_pub_enabled

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -512,7 +512,7 @@ RSpec.describe Post do
       end
     end
 
-    context "without activty pub enabled on the category" do
+    context "without activity pub enabled on the category" do
       it "does nothing" do
         expect(post.perform_activity_pub_activity(:create)).to eq(false)
         expect(post.reload.activity_pub_object.present?).to eq(false)
@@ -598,6 +598,27 @@ RSpec.describe Post do
             freeze_time
             published_at = Time.now.utc.iso8601
             perform_create
+            expect(post.activity_pub_published?).to eq(true)
+            # rubocop:disable Discourse/TimeEqMatcher
+            expect(post.activity_pub_published_at).to eq(published_at)
+            expect(post.activity_pub_object.published_at).to eq(published_at)
+            expect(post.activity_pub_object.create_activity.published_at).to eq(published_at)
+            # rubocop:enable Discourse/TimeEqMatcher
+            unfreeze_time
+          end
+
+          it "outputs only one date for activity_pub_published_at when there are multiple published_at custom fields" do
+            freeze_time
+            published_at = Time.now.utc.iso8601
+            perform_create
+
+            # Create a second custom field
+            PostCustomField.create!(
+              post_id: post.id,
+              name: "activity_pub_published_at",
+              value: published_at,
+            )
+
             expect(post.activity_pub_published?).to eq(true)
             # rubocop:disable Discourse/TimeEqMatcher
             expect(post.activity_pub_published_at).to eq(published_at)


### PR DESCRIPTION
Not the final fix, but at least it avoids showing "invalid date" in the UI for these cases where multiple custom fields are created. 