### PR TITLE
DEV: Remove the widget code

### DIFF
--- a/assets/javascripts/discourse/initializers/activity-pub-initializer.gjs
+++ b/assets/javascripts/discourse/initializers/activity-pub-initializer.gjs
@@ -109,14 +109,10 @@ export default {
                 activity_pub_updated_at: data.model.updated_at,
                 activity_pub_delivered_at: data.model.delivered_at,
               };
-              topic.postStream
-                .triggerActivityPubStateChange(data.model.id, props)
-                .then(() =>
-                  // TODO (glimmer-post-stream) the Glimmer Post Stream does not listen to this event
-                  this.appEvents.trigger("post-stream:refresh", {
-                    id: data.model.id,
-                  })
-                );
+              topic.postStream.triggerActivityPubStateChange(
+                data.model.id,
+                props
+              );
               this.appEvents.trigger(
                 "activity-pub:post-updated",
                 data.model.id,


### PR DESCRIPTION
Eliminate obsolete `post-stream:refresh` event triggers. These events were marked as TODO for removal after the Glimmer migration and are no longer needed.

This cleanup improves code clarity and reduces unnecessary event emissions, with no impact on functionality since the events were unused by the current post-stream implementation.