### PR TITLE
DEV: Replace `findBy` with native `find` in activity pub plugin JS

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-activity-pub-actor.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-activity-pub-actor.js
@@ -62,6 +62,6 @@ export default class AdminPluginsActivityPubActor extends Controller {
 
   @action
   removeActor(actorId) {
-    this.actors.removeObject(this.actors.findBy("id", actorId));
+    this.actors.removeObject(this.actors.find((item) => item.id === actorId));
   }
 }

--- a/assets/javascripts/discourse/initializers/activity-pub-initializer.gjs
+++ b/assets/javascripts/discourse/initializers/activity-pub-initializer.gjs
@@ -31,7 +31,7 @@ export default {
         if (topic.activity_pub_enabled && currentUser?.staff) {
           const firstPost = topic
             .get("postStream.posts")
-            .findBy("post_number", 1);
+            .find((item) => item.post_number === 1);
           return {
             icon: "discourse-activity-pub",
             className: "show-activity-pub-topic-admin",
@@ -82,7 +82,7 @@ export default {
           class extends Superclass {
             getActivityPubPostActor(postId) {
               const postActors = this.activity_pub_post_actors || [];
-              return postActors.findBy("post_id", postId);
+              return postActors.find((item) => item.post_id === postId);
             }
           }
       );


### PR DESCRIPTION
Refactor usage of `findBy` to native `find` in JavaScript for the Discourse Activity Pub plugin. Affected files include initializer, controller, and utility methods for improved code consistency and compatibility.