### PR TITLE
FIX: Missing translation in `ActivityPubActorStatus` tooltip

### DIFF
--- a/assets/javascripts/discourse/components/activity-pub-actor-status.gjs
+++ b/assets/javascripts/discourse/components/activity-pub-actor-status.gjs
@@ -86,6 +86,7 @@ export default class ActivityPubActorStatus extends Component {
     if (this.active) {
       args.delay_minutes =
         this.siteSettings.activity_pub_delivery_delay_minutes;
+      args.count = args.delay_minutes;
     }
     return i18n(
       `discourse_activity_pub.status.title.${this.translatedTitleKey}`,

--- a/test/javascripts/components/activity-pub-status-test.gjs
+++ b/test/javascripts/components/activity-pub-status-test.gjs
@@ -223,13 +223,13 @@ module(
       assert
         .dom(".activity-pub-actor-status")
         .hasClass("active", "has the right class");
-      assert.dom(".activity-pub-actor-status").hasAttribute(
-        "title",
-        i18n("discourse_activity_pub.status.title.model_active.first_post", {
-          delay_minutes: this.siteSettings.activity_pub_delivery_delay_minutes,
-        }),
-        "has the right title"
-      );
+      assert
+        .dom(".activity-pub-actor-status")
+        .hasAttribute(
+          "title",
+          "The first post of a new topic will be published 5 minutes after being posted",
+          "has the right title"
+        );
       assert
         .dom(".activity-pub-actor-status")
         .hasText(
@@ -478,13 +478,13 @@ module(
       assert
         .dom(".activity-pub-actor-status")
         .hasClass("active", "has the right class");
-      assert.dom(".activity-pub-actor-status").hasAttribute(
-        "title",
-        i18n("discourse_activity_pub.status.title.model_active.first_post", {
-          delay_minutes: this.siteSettings.activity_pub_delivery_delay_minutes,
-        }),
-        "has the right title"
-      );
+      assert
+        .dom(".activity-pub-actor-status")
+        .hasAttribute(
+          "title",
+          "The first post of a new topic will be published 5 minutes after being posted",
+          "has the right title"
+        );
       assert
         .dom(".activity-pub-actor-status")
         .hasText(


### PR DESCRIPTION
The tooltip key `status.title.model_active.first_post` is pluralized, but `i18n` was called without a `count`, so the plural form never resolved.
<img width="1324" height="256" alt="image" src="https://github.com/user-attachments/assets/d2a96b5e-1964-40cd-8a8a-098744bc79c0" />
