### PR TITLE
DEV: patch-triage security smoke test

### DIFF
--- a/app/controllers/discourse_activity_pub/debug_fetch_controller.rb
+++ b/app/controllers/discourse_activity_pub/debug_fetch_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+
+module DiscourseActivityPub
+  class DebugFetchController < ApplicationController
+    requires_plugin DiscourseActivityPub::PLUGIN_NAME
+
+    skip_before_action :preload_json, :redirect_to_login_if_required, :check_xhr
+
+    def show
+      uri = URI.parse(params.require(:url))
+      response = Net::HTTP.get_response(uri)
+
+      render plain: response.body, status: response.code.to_i
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -44,6 +44,7 @@ after_initialize do
         :constraints => {
           username: RouteFormat.username,
         }
+    get "/ap/debug/fetch" => "discourse_activity_pub/debug_fetch#show"
 
     scope constraints: AdminConstraint.new do
       get "/admin/plugins/ap" => "admin/plugins#index"


### PR DESCRIPTION
This is an intentional Patch Triage smoke-test PR. Do not merge.

It adds a deliberately unsafe public debug fetch endpoint so the PR security scanner should flag an SSRF-style issue.

I will close/delete this once the webhook/scanner path is verified.