### PR TITLE
SECURITY: ActivityPub actor payloads expose hidden tag names

### DIFF
--- a/app/controllers/admin/discourse_activity_pub/actor_controller.rb
+++ b/app/controllers/admin/discourse_activity_pub/actor_controller.rb
@@ -123,7 +123,11 @@ module Admin::DiscourseActivityPub
         render json:
                  success_json.merge(
                    actor:
-                     DiscourseActivityPub::DetailedActorSerializer.new(actor, root: false).as_json,
+                     DiscourseActivityPub::DetailedActorSerializer.new(
+                       actor,
+                       root: false,
+                       scope: guardian,
+                     ).as_json,
                  )
       else
         render json: failed_json.merge(errors: handler.errors.map(&:message)), status: :bad_request

--- a/app/serializers/discourse_activity_pub/about_serializer.rb
+++ b/app/serializers/discourse_activity_pub/about_serializer.rb
@@ -6,13 +6,13 @@ module DiscourseActivityPub
 
     def category_actors
       object.category_actors.map do |actor|
-        DiscourseActivityPub::CardActorSerializer.new(actor, root: false).as_json
+        DiscourseActivityPub::CardActorSerializer.new(actor, root: false, scope: scope).as_json
       end
     end
 
     def tag_actors
       object.tag_actors.map do |actor|
-        DiscourseActivityPub::CardActorSerializer.new(actor, root: false).as_json
+        DiscourseActivityPub::CardActorSerializer.new(actor, root: false, scope: scope).as_json
       end
     end
   end

--- a/app/serializers/discourse_activity_pub/actor_serializer.rb
+++ b/app/serializers/discourse_activity_pub/actor_serializer.rb
@@ -23,7 +23,7 @@ module DiscourseActivityPub
     end
 
     def include_model_name?
-      object.model_type === "Tag"
+      object.model_type == "Tag" && object.model.present? && scope&.can_see_tag?(object.model)
     end
 
     def can_admin

--- a/plugin.rb
+++ b/plugin.rb
@@ -223,6 +223,7 @@ after_initialize do
       actors[actor.model_type.downcase.to_sym] << DiscourseActivityPub::SiteActorSerializer.new(
         actor,
         root: false,
+        scope: scope,
       ).as_json
     end
     actors.as_json
@@ -327,7 +328,11 @@ after_initialize do
     :activity_pub_actor,
     include_condition: -> { object.topic.activity_pub_enabled },
   ) do
-    DiscourseActivityPub::ActorSerializer.new(object.topic.activity_pub_actor, root: false).as_json
+    DiscourseActivityPub::ActorSerializer.new(
+      object.topic.activity_pub_actor,
+      root: false,
+      scope: scope,
+    ).as_json
   end
   add_to_serializer(
     :topic_view,

--- a/spec/requests/site_controller_spec.rb
+++ b/spec/requests/site_controller_spec.rb
@@ -4,6 +4,30 @@ RSpec.describe SiteController do
   ADDITIONAL_QUERY_LIMIT = 4
 
   describe "#site" do
+    context "with activity pub tag actors" do
+      fab!(:visible_tag) { Fabricate(:tag, name: "visible") }
+      fab!(:hidden_tag) { Fabricate(:tag, name: "hidden") }
+
+      before do
+        SiteSetting.activity_pub_enabled = true
+        Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
+        toggle_activity_pub(visible_tag)
+        toggle_activity_pub(hidden_tag)
+      end
+
+      it "does not include hidden tag model names for anonymous users" do
+        get "/site.json"
+
+        expect(response.status).to eq(200)
+        tag_actors = response.parsed_body.dig("activity_pub_actors", "tag")
+        hidden_actor = tag_actors.find { |actor| actor["id"] == hidden_tag.activity_pub_actor.id }
+
+        expect(tag_actors.map { |actor| actor["model_name"] }).to include(visible_tag.name)
+        expect(hidden_actor).to be_present
+        expect(hidden_actor).not_to have_key("model_name")
+      end
+    end
+
     context "with activity pub categories" do
       let!(:category1) { Fabricate(:category) }
       let!(:category2) { Fabricate(:category) }


### PR DESCRIPTION
## Summary

Anonymous users could see the names of hidden tags by querying /site.json or viewing topics where ActivityPub is enabled. While this does not expose the content of topics within those tags, it discloses the existence and names of tags intended to be private/internal.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1230

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>