### PR TITLE
SECURITY: ActivityPub object JSON leaks restricted post content

### DIFF
--- a/app/controllers/discourse_activity_pub/a_p/objects_controller.rb
+++ b/app/controllers/discourse_activity_pub/a_p/objects_controller.rb
@@ -19,6 +19,7 @@ class DiscourseActivityPub::AP::ObjectsController < ApplicationController
   before_action :validate_headers, unless: :browser_request?
   before_action :ensure_object_exists, if: :is_object_controller
   before_action :ensure_model_exists, if: -> { is_object_controller && browser_request? }
+  before_action :ensure_can_access_object_model, if: :is_object_controller
   before_action :set_raw_body
 
   def show
@@ -107,6 +108,12 @@ class DiscourseActivityPub::AP::ObjectsController < ApplicationController
 
   def ensure_model_exists
     raise Discourse::NotFound if @object.model_trashed?
+  end
+
+  def ensure_can_access_object_model
+    unless guardian.can_see?(@object.model) && @object.model&.activity_pub_enabled
+      render_activity_pub_error("not_available", 401)
+    end
   end
 
   def render_activity_json(json)

--- a/spec/requests/discourse_activity_pub/ap/objects_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/objects_controller_spec.rb
@@ -115,6 +115,37 @@ RSpec.describe DiscourseActivityPub::AP::ObjectsController do
         expect(parsed_body["to"]).to eq([public_collection_id, group&.ap_id])
         expect(parsed_body["cc"]).to eq(nil)
       end
+
+      context "when the published object's category is no longer public" do
+        before do
+          create_activity.publish!
+          object.update!(content: "published restricted content")
+          setup_logging
+        end
+        after { teardown_logging }
+
+        it "returns not available when the category is made read restricted" do
+          category.set_permissions(staff: :full)
+          category.save!
+
+          get_object(object)
+
+          expect_request_error(response, "not_available", 401)
+          expect(response.body).not_to include(object.content)
+        end
+
+        it "returns not available when the topic is moved to a private category" do
+          private_category = Fabricate(:category)
+          private_category.set_permissions(staff: :full)
+          private_category.save!
+          topic.update!(category: private_category)
+
+          get_object(object)
+
+          expect_request_error(response, "not_available", 401)
+          expect(response.body).not_to include(object.content)
+        end
+      end
     end
 
     context "when requested from a browser" do


### PR DESCRIPTION
## Summary

ActivityPub object JSON leaks restricted post content. Only applies if a public topic gets moved to a private category or is made private in some other way. 

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1213
- Affected file: https://github.com/discourse/discourse-activity-pub/blob/main/app/controllers/discourse_activity_pub/a_p/objects_controller.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>