### PR TITLE
DEV: Ensure signature keyId resolution does not fetch arbitrary internal URLs

### DIFF
--- a/lib/discourse_activity_pub/request.rb
+++ b/lib/discourse_activity_pub/request.rb
@@ -188,10 +188,10 @@ module DiscourseActivityPub
 
     def safe_request_uri
       return unless DiscourseActivityPub::URI.valid_url?(uri)
-      return if uri.host.blank?
+      return if uri.host.blank? || disallowed_ip?(uri.host)
 
       resolved_ip = FinalDestination::SSRFDetector.lookup_and_filter_ips(uri.host).first
-      return if resolved_ip.blank?
+      return if resolved_ip.blank? || disallowed_ip?(resolved_ip)
 
       safe_uri = uri.dup
 
@@ -204,6 +204,12 @@ module DiscourseActivityPub
            SocketError,
            Timeout::Error
       nil
+    end
+
+    def disallowed_ip?(host)
+      !FinalDestination::SSRFDetector.ip_allowed?(IPAddr.new(host))
+    rescue IPAddr::InvalidAddressError
+      false
     end
   end
 end

--- a/spec/lib/discourse_activity_pub/request_spec.rb
+++ b/spec/lib/discourse_activity_pub/request_spec.rb
@@ -56,10 +56,6 @@ RSpec.describe DiscourseActivityPub::Request do
   describe "#expects" do
     context "with an unsafe destination" do
       it "does not perform the request" do
-        FinalDestination::SSRFDetector
-          .expects(:lookup_and_filter_ips)
-          .with("127.0.0.1")
-          .raises(FinalDestination::SSRFDetector::DisallowedIpError)
         Excon.expects(:get).never
 
         request = described_class.new(uri: "https://127.0.0.1/admin")
@@ -240,10 +236,6 @@ RSpec.describe DiscourseActivityPub::Request do
           .expects(:lookup_and_filter_ips)
           .with("remote.com")
           .returns(["93.184.216.34"])
-        FinalDestination::SSRFDetector
-          .expects(:lookup_and_filter_ips)
-          .with("127.0.0.1")
-          .raises(FinalDestination::SSRFDetector::DisallowedIpError)
 
         Excon
           .expects(:get)
@@ -328,10 +320,6 @@ RSpec.describe DiscourseActivityPub::Request do
 
     context "with an unsafe destination" do
       it "does not perform the request" do
-        FinalDestination::SSRFDetector
-          .expects(:lookup_and_filter_ips)
-          .with("127.0.0.1")
-          .raises(FinalDestination::SSRFDetector::DisallowedIpError)
         Excon.expects(:post).never
 
         result = described_class.post_json_ld(uri: "https://127.0.0.1/inbox", body: accept_json)

--- a/spec/requests/discourse_activity_pub/ap/inboxes_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/inboxes_controller_spec.rb
@@ -326,6 +326,45 @@ RSpec.describe DiscourseActivityPub::AP::InboxesController do
           end
         end
 
+        context "with an actor keyId on an allowed internal host" do
+          before do
+            setup_logging
+            SiteSetting.allowed_internal_hosts = "127.0.0.1"
+          end
+
+          after { teardown_logging }
+
+          it "does not fetch or store the actor" do
+            private_actor_id = "http://127.0.0.1/u/#{SecureRandom.hex(8)}"
+            actor_json = build_actor_json(public_key: keypair.public_key.to_pem)
+            actor_json[:id] = private_actor_id
+            actor_json[:inbox] = "#{private_actor_id}/inbox"
+            actor_json[:outbox] = "#{private_actor_id}/outbox"
+            actor_json[:publicKey][:id] = "#{private_actor_id}#main-key"
+            actor_json[:publicKey][:owner] = private_actor_id
+
+            stub_request(:get, private_actor_id).to_return(
+              body: actor_json.to_json,
+              headers: {
+                "Content-Type" => "application/json",
+              },
+              status: 200,
+            )
+
+            headers = build_post_headers(key_id: actor_json[:publicKey][:id], keypair: keypair)
+            post_to_inbox(group, body: post_body, headers: headers)
+
+            expect_request_error(
+              response,
+              "actor_not_found_for_key",
+              401,
+              key_id: actor_json[:publicKey][:id],
+            )
+            expect(DiscourseActivityPubActor.exists?(ap_id: private_actor_id)).to eq(false)
+            expect(a_request(:get, private_actor_id)).not_to have_been_made
+          end
+        end
+
         context "with an invalid digest" do
           let!(:invalid_digest) { Digest::SHA256.base64digest("invalid body") }
           let!(:headers) do


### PR DESCRIPTION
Prevents remote fetches from reaching internal IP addresses by explicitly validating that both the host and the resolved IP are not private, even if the host is included in the `allowed_internal_hosts` setting. Security hardening more than a security fix.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>