### PR TITLE
SECURITY: ActivityPub collection response can include hidden post content

### DIFF
--- a/app/controllers/discourse_activity_pub/a_p/collections_controller.rb
+++ b/app/controllers/discourse_activity_pub/a_p/collections_controller.rb
@@ -7,10 +7,31 @@ class DiscourseActivityPub::AP::CollectionsController < DiscourseActivityPub::AP
   before_action :ensure_can_access_collection
 
   def show
-    render_activity_json(@collection.ap.json)
+    render_activity_json(collection_json)
   end
 
   protected
+
+  def collection_json
+    collection = @collection.ap
+    collection.items = collection.items.select { |item| can_see_collection_item?(item) }
+    collection_serializer(collection).new(collection, root: false).as_json.with_indifferent_access
+  end
+
+  def collection_serializer(collection)
+    "#{collection.class.name}Serializer".constantize
+  end
+
+  def can_see_collection_item?(item)
+    model = collection_item_model(item)
+    model.blank? || guardian.can_see?(model)
+  end
+
+  def collection_item_model(item)
+    stored = item.stored
+    stored = stored.base_object if stored.respond_to?(:base_object)
+    stored.model if stored.respond_to?(:model)
+  end
 
   def ensure_collection_exists
     unless @collection = DiscourseActivityPubCollection.find_by(ap_key: params[:key], local: true)

--- a/app/models/discourse_activity_pub/post.rb
+++ b/app/models/discourse_activity_pub/post.rb
@@ -331,6 +331,25 @@ module DiscourseActivityPub::Post
     perform_activity_pub_activity(:delete)
   end
 
+  def hide!(post_action_type_id, reason = nil, custom_message: nil)
+    super.tap { update_activity_pub_object_visibility }
+  end
+
+  def unhide!
+    super.tap { update_activity_pub_object_visibility }
+  end
+
+  def update_activity_pub_object_visibility
+    object = DiscourseActivityPubObject.unscoped.find_by(model_id: self.id, model_type: "Post")
+    return unless object
+
+    if hidden?
+      object.tombstone! unless object.tombstoned?
+    elsif object.tombstoned?
+      object.restore_tombstoned!
+    end
+  end
+
   def activity_pub_deliver!
     return false if !activity_pub_published? || activity_pub_taxonomy_followers.blank?
     activity_pub_deliver_create

--- a/lib/discourse_activity_pub/a_p/collection.rb
+++ b/lib/discourse_activity_pub/a_p/collection.rb
@@ -6,6 +6,11 @@ module DiscourseActivityPub
 
       attr_accessor :items_to_process
 
+      def items=(items)
+        @items = items
+        @ordered_items = nil
+      end
+
       def id
         stored.ap_id
       end

--- a/spec/requests/discourse_activity_pub/ap/collections_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/collections_controller_spec.rb
@@ -72,6 +72,38 @@ RSpec.describe DiscourseActivityPub::AP::CollectionsController do
         expect(parsed_body["orderedItems"].first["id"]).to eq(note2.ap_id)
         expect(parsed_body["orderedItems"].last["id"]).to eq(note1.ap_id)
       end
+
+      it "does not return hidden post content in collection items" do
+        stale_hidden_post = Fabricate(:post, topic: collection.model)
+        stale_hidden_note =
+          Fabricate(
+            :discourse_activity_pub_object_note,
+            model: stale_hidden_post,
+            collection_id: collection.id,
+            created_at: 30.seconds.ago,
+          )
+
+        note2.update!(content: "Hidden ActivityPub content #{SecureRandom.hex}")
+        stale_hidden_note.update!(content: "Stale hidden ActivityPub content #{SecureRandom.hex}")
+        stale_hidden_post.update_columns(
+          hidden: true,
+          hidden_at: Time.zone.now,
+          hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
+        )
+
+        post2.hide!(PostActionType.types[:inappropriate])
+        get_object(collection)
+
+        expect(response.status).to eq(200)
+        expect(parsed_body["orderedItems"].map { |item| item["id"] }).to eq([note1.ap_id])
+        expect(response.body).not_to include(note2.content)
+        expect(response.body).not_to include(stale_hidden_note.content)
+        expect(DiscourseActivityPubObject.unscoped.find(note2.id)).to be_tombstoned
+        expect(DiscourseActivityPubObject.unscoped.find(stale_hidden_note.id)).not_to be_tombstoned
+
+        post2.unhide!
+        expect(DiscourseActivityPubObject.unscoped.find(note2.id)).not_to be_tombstoned
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

ActivityPub collection response can include hidden post content

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1211
- Affected file: https://github.com/discourse/discourse-activity-pub/blob/main/app/controllers/discourse_activity_pub/a_p/collections_controller.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>