### PR TITLE
SECURITY: ActivityPub user actors expose full names when names are disabled

### DIFF
--- a/app/models/discourse_activity_pub/user.rb
+++ b/app/models/discourse_activity_pub/user.rb
@@ -48,7 +48,7 @@ module DiscourseActivityPub::User
   end
 
   def activity_pub_name
-    name
+    name if SiteSetting.enable_names?
   end
 
   def activity_pub_skip_email_validation

--- a/app/models/discourse_activity_pub_actor.rb
+++ b/app/models/discourse_activity_pub_actor.rb
@@ -157,6 +157,12 @@ class DiscourseActivityPubActor < ActiveRecord::Base
     end
   end
 
+  def name
+    return nil if local? && model_type == "User" && !SiteSetting.enable_names?
+
+    read_attribute(:name)
+  end
+
   def followers_collection
     @followers_collection ||=
       begin

--- a/lib/discourse_activity_pub/actor_handler.rb
+++ b/lib/discourse_activity_pub/actor_handler.rb
@@ -204,7 +204,8 @@ module DiscourseActivityPub
       )
 
       actor.username = username
-      actor.name = model.activity_pub_name if model.activity_pub_name
+      name = model.activity_pub_name
+      actor.name = name if name || model_type == "User"
     end
 
     def update_actor_from_opts

--- a/lib/discourse_activity_pub/bulk/publish.rb
+++ b/lib/discourse_activity_pub/bulk/publish.rb
@@ -248,7 +248,12 @@ module DiscourseActivityPub
             object: user.activity_pub_actor,
             base_type: AP::Actor.type,
             type: AP::Actor::Person.type,
-          ).merge(username: user.username, name: user.name, model_id: user.id, model_type: "User")
+          ).merge(
+            username: user.username,
+            name: user.activity_pub_name,
+            model_id: user.id,
+            model_type: "User",
+          )
         end
       end
 

--- a/spec/lib/discourse_activity_pub/actor_handler_spec.rb
+++ b/spec/lib/discourse_activity_pub/actor_handler_spec.rb
@@ -185,6 +185,20 @@ RSpec.describe DiscourseActivityPub::ActorHandler do
           expect(DiscourseActivityPubActor.all.size).to eq(actor_count)
         end
 
+        context "when names are disabled" do
+          before do
+            SiteSetting.enable_names = false
+            user.update!(name: "Hidden Name")
+            actor.update!(name: user.name)
+          end
+
+          it "clears the actor name" do
+            described_class.update_or_create_actor(user)
+
+            expect(actor.reload.read_attribute(:name)).to be_nil
+          end
+        end
+
         context "when required attributes are blank" do
           before { actor.update(public_key: nil, private_key: nil, inbox: nil, outbox: nil) }
 

--- a/spec/lib/discourse_activity_pub/bulk/publish_spec.rb
+++ b/spec/lib/discourse_activity_pub/bulk/publish_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe DiscourseActivityPub::Bulk::Publish do
             expect(post4.user.activity_pub_actor.username).to eq(post4.user.username)
           end
 
+          it "omits user actor names when names are disabled" do
+            SiteSetting.enable_names = false
+            post1.user.update!(name: "Hidden Name")
+
+            described_class.perform(actor_id: actor.id)
+
+            expect(post1.reload.user.activity_pub_actor.read_attribute(:name)).to be_nil
+          end
+
           it "creates the right post objects" do
             described_class.perform(actor_id: actor.id)
             expect(post1.reload.activity_pub_object.content).to eq(post1.cooked)

--- a/spec/requests/discourse_activity_pub/ap/actors_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/actors_controller_spec.rb
@@ -84,6 +84,27 @@ RSpec.describe DiscourseActivityPub::AP::ActorsController do
       expect(parsed_body).to eq(group.reload.ap.json)
     end
 
+    context "with a person actor" do
+      fab!(:user_with_name) { Fabricate(:user, name: "Hidden Name") }
+      fab!(:named_person) do
+        Fabricate(
+          :discourse_activity_pub_actor_person,
+          local: true,
+          model: user_with_name,
+          name: user_with_name.name,
+        )
+      end
+
+      before { SiteSetting.enable_names = false }
+
+      it "omits stored names from actor json" do
+        get_object(named_person)
+
+        expect(response.status).to eq(200)
+        expect(parsed_body).not_to have_key("name")
+      end
+    end
+
     it "ensures actor has required attributes" do
       person.update_columns(inbox: "/inbox", outbox: "/outbox")
       get_object(person)


### PR DESCRIPTION
## Summary

ActivityPub user actors expose full names when names are disabled

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1226
- Affected file: https://github.com/discourse/discourse-activity-pub/blob/main/app/models/discourse_activity_pub/user.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>