### PR TITLE
SECURITY: ActivityPub actor show leaks restricted category metadata

### DIFF
--- a/app/controllers/discourse_activity_pub/actor_controller.rb
+++ b/app/controllers/discourse_activity_pub/actor_controller.rb
@@ -17,6 +17,8 @@ module DiscourseActivityPub
     before_action :find_target_actor, only: %i[follow unfollow reject]
 
     def show
+      guardian.ensure_can_see!(@actor.model)
+
       render_serialized(@actor, DiscourseActivityPub::DetailedActorSerializer, root: "actor")
     end
 

--- a/spec/requests/discourse_activity_pub/actor_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/actor_controller_spec.rb
@@ -85,6 +85,25 @@ RSpec.describe DiscourseActivityPub::ActorController do
         end
       end
     end
+
+    context "with a restricted category actor" do
+      fab!(:private_group, :group)
+      fab!(:private_category) { Fabricate(:private_category, group: private_group) }
+
+      fab!(:private_category_actor) do
+        Fabricate(:discourse_activity_pub_actor_group, model: private_category, local: true)
+      end
+
+      before { toggle_activity_pub(private_category) }
+
+      it "blocks users who cannot see the category" do
+        get "/ap/local/actor/#{private_category_actor.id}.json"
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["errors"]).to be_present
+        expect(response.body).not_to include(private_category.name)
+      end
+    end
   end
 
   describe "#follows" do


### PR DESCRIPTION
## Summary

ActivityPub actor show leaks restricted category metadata

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1218
- Affected file: https://github.com/discourse/discourse-activity-pub/blob/main/app/controllers/discourse_activity_pub/actor_controller.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>