### PR TITLE
SECURITY: Authorization destroy endpoint deletes other users' ActivityPub authorizations

### DIFF
--- a/app/controllers/discourse_activity_pub/authorization_controller.rb
+++ b/app/controllers/discourse_activity_pub/authorization_controller.rb
@@ -91,11 +91,12 @@ module DiscourseActivityPub
     def destroy
       params.require(:auth_id)
 
-      authorization = DiscourseActivityPubAuthorization.find_by(id: params[:auth_id])
+      authorization =
+        DiscourseActivityPubAuthorization.find_by(id: params[:auth_id], user_id: current_user.id)
       if authorization && authorization.destroy!
         render json: success_json
       else
-        render json: failed_json, status: :unprocessable_content
+        render json: failed_json, status: :not_found
       end
     end
 

--- a/spec/requests/discourse_activity_pub/authorization_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/authorization_controller_spec.rb
@@ -399,12 +399,25 @@ RSpec.describe DiscourseActivityPub::AuthorizationController do
     before { sign_in(user) }
 
     context "with a valid authorization id" do
-      let!(:authorization) { Fabricate(:discourse_activity_pub_authorization_mastodon) }
+      let!(:authorization) { Fabricate(:discourse_activity_pub_authorization_mastodon, user: user) }
 
       it "destroys the authorization" do
         delete "/ap/auth/destroy/#{authorization.id}"
         expect(response).to be_successful
         expect(DiscourseActivityPubAuthorization.find_by(id: authorization.id)).to eq(nil)
+      end
+    end
+
+    context "with another user's authorization id" do
+      it "returns not found and preserves the authorization" do
+        other_user = Fabricate(:user)
+        authorization = Fabricate(:discourse_activity_pub_authorization_mastodon, user: other_user)
+
+        delete "/ap/auth/destroy/#{authorization.id}"
+
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["failed"]).to eq("FAILED")
+        expect(DiscourseActivityPubAuthorization.exists?(authorization.id)).to eq(true)
       end
     end
 


### PR DESCRIPTION
## Summary

Authorization destroy endpoint deletes other users' ActivityPub authorizations

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1219
- Affected file: https://github.com/discourse/discourse-activity-pub/blob/main/app/controllers/discourse_activity_pub/authorization_controller.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>