### PR TITLE
FIX: Reuse a topic's tombstoned collection when moving posts in

### DIFF
--- a/app/models/discourse_activity_pub/topic.rb
+++ b/app/models/discourse_activity_pub/topic.rb
@@ -71,6 +71,11 @@ module DiscourseActivityPub::Topic
   end
 
   def create_activity_pub_collection!
+    if existing = DiscourseActivityPubCollection.unscoped.find_by(model: self)
+      existing.restore_tombstoned! if existing.tombstoned?
+      return association(:activity_pub_object).target = existing
+    end
+
     params = { local: true, ap_type: activity_pub_default_object_type, name: activity_pub_name }
     attributed_to = DiscourseActivityPub::ActorHandler.update_or_create_actor(self.user)
     params[:attributed_to_id] = attributed_to.ap_id if attributed_to

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Topic do
     end
   end
 
-  describe "move_posts" do
+  describe "move_posts", :aggregate_failures do
     context "with posts in an ap category" do
       let!(:note1) { Fabricate(:discourse_activity_pub_object_note, model: post1) }
       let!(:activity1) { Fabricate(:discourse_activity_pub_activity_create, object: note1) }
@@ -54,357 +54,230 @@ RSpec.describe Topic do
 
         before do
           toggle_activity_pub(category1, publication_type: "full_topic")
-          note1.collection_id = collection1.id
-          note1.save!
+          note1.update!(collection_id: collection1.id)
         end
 
-        context "when moved to a new full_topic topic" do
-          before do
-            @new_topic =
-              topic1.move_posts(
-                user1,
-                [post1.id, post3.id],
-                title: "New topic in ap category",
-                category_id: category1.id,
-              )
-          end
-
-          it "moves the posts" do
-            expect([topic1.id, topic2.id, topic3.id]).to_not include(@new_topic.id)
-            expect(@new_topic.first_post.raw).to eq(post1.raw)
-            expect(post2.reload.topic.id).to eq(topic1.id)
-          end
-
-          it "creates a collection for the new topic" do
-            expect(@new_topic.activity_pub_object&.ap&.collection?).to eq(true)
-          end
-
-          it "does not create new objects or activities" do
-            expect(DiscourseActivityPubObject.all.size).to eq(3)
-            expect(DiscourseActivityPubActivity.all.size).to eq(3)
-          end
-
-          it "updates the note references" do
-            expect(note1.reload.model_id).to eq(@new_topic.first_post.id)
-            expect(note1.collection_id).to eq(@new_topic.activity_pub_object.id)
-            expect(note2.reload.collection_id).to eq(collection1.id)
-          end
-        end
-
-        context "when moved to an existing full_topic topic" do
-          before { topic1.move_posts(user1, [post1.id, post3.id], destination_topic_id: topic2.id) }
-
-          it "moves the posts" do
-            first_post = topic2.reload.first_post
-            expect(topic2.posts.size).to eq(2)
-            expect(first_post.raw).to eq(post1.raw)
-            expect(post2.reload.topic_id).to eq(topic1.id)
-            expect(post3.reload.topic_id).to eq(topic2.id)
-          end
-
-          it "does not create new collections, objects or activities" do
-            expect(DiscourseActivityPubCollection.all.size).to eq(2)
-            expect(DiscourseActivityPubObject.all.size).to eq(3)
-            expect(DiscourseActivityPubActivity.all.size).to eq(3)
-          end
-
-          it "updates the note references" do
-            first_post = topic2.reload.first_post
-            expect(note1.reload.model_id).to eq(first_post.id)
-            expect(note1.collection_id).to eq(collection2.id)
-            expect(note2.reload.collection_id).to eq(collection1.id)
-          end
-        end
-
-        context "when the destination topic's collection was tombstoned" do
-          before { collection2.tombstone! }
-
-          it "revives it instead of failing to move posts in" do
-            expect {
-              topic1.move_posts(user1, [post1.id, post3.id], destination_topic_id: topic2.id)
-            }.not_to raise_error
-            expect(DiscourseActivityPubCollection.all).to contain_exactly(collection1, collection2)
-            expect(collection2.reload).not_to be_tombstoned
-          end
-        end
-
-        context "when moved to a new non-ap topic" do
-          before do
+        it "moves the posts to a new full_topic topic, creating a collection and reassigning the notes" do
+          new_topic =
             topic1.move_posts(
               user1,
               [post1.id, post3.id],
-              title: "New topic in another category",
-              category_id: category2.id,
+              title: "New topic in ap category",
+              category_id: category1.id,
             )
-            @new_topic = post3.reload.topic
-            @first_post = @new_topic.first_post
-          end
 
-          it "moves the posts" do
-            expect(@new_topic.category_id).to eq(category2.id)
-            expect(post2.reload.topic.category_id).to eq(category1.id)
-            expect(post3.reload.topic.category_id).to eq(category2.id)
-          end
-
-          it "does not create new collections, objects or activities" do
-            expect(DiscourseActivityPubCollection.all.size).to eq(2)
-            expect(DiscourseActivityPubObject.all.size).to eq(3)
-            expect(DiscourseActivityPubActivity.all.size).to eq(3)
-          end
-
-          it "updates the note references" do
-            expect(note1.reload.model_id).to eq(@first_post.id)
-            expect(note1.reload.collection_id).to eq(nil)
-            expect(note2.reload.collection_id).to eq(collection1.id)
-          end
+          expect([topic1.id, topic2.id, topic3.id]).not_to include(new_topic.id)
+          expect(new_topic.first_post.raw).to eq(post1.raw)
+          expect(post2.reload.topic_id).to eq(topic1.id)
+          expect(new_topic.activity_pub_object.ap.collection?).to eq(true)
+          expect(DiscourseActivityPubObject.count).to eq(3)
+          expect(DiscourseActivityPubActivity.count).to eq(3)
+          expect(note1.reload.model_id).to eq(new_topic.first_post.id)
+          expect(note1.collection_id).to eq(new_topic.activity_pub_object.id)
+          expect(note2.reload.collection_id).to eq(collection1.id)
         end
 
-        context "when moved to an existing non-ap topic" do
-          before do
-            topic1.move_posts(
-              user1,
-              [post1.id, post3.id],
-              destination_topic_id: topic3.id,
-              category_id: category2.id,
-            )
-            @first_post = topic3.first_post.reload
-          end
+        it "moves the posts to an existing full_topic topic, reassigning the notes without creating records" do
+          topic1.move_posts(user1, [post1.id, post3.id], destination_topic_id: topic2.id)
 
-          it "moves the posts" do
-            expect(topic3.posts.size).to eq(2)
-            expect(@first_post.raw).to eq(post1.raw)
-            expect(post2.reload.topic_id).to eq(topic1.id)
-            expect(post3.reload.topic_id).to eq(topic3.id)
-          end
+          first_post = topic2.reload.first_post
+          expect(topic2.posts.size).to eq(2)
+          expect(first_post.raw).to eq(post1.raw)
+          expect(post2.reload.topic_id).to eq(topic1.id)
+          expect(post3.reload.topic_id).to eq(topic2.id)
+          expect(DiscourseActivityPubCollection.count).to eq(2)
+          expect(DiscourseActivityPubObject.count).to eq(3)
+          expect(DiscourseActivityPubActivity.count).to eq(3)
+          expect(note1.reload.model_id).to eq(first_post.id)
+          expect(note1.collection_id).to eq(collection2.id)
+          expect(note2.reload.collection_id).to eq(collection1.id)
+        end
 
-          it "does not create new collections, objects or activities" do
-            expect(DiscourseActivityPubCollection.all.size).to eq(2)
-            expect(DiscourseActivityPubObject.all.size).to eq(3)
-            expect(DiscourseActivityPubActivity.all.size).to eq(3)
-          end
+        it "revives a tombstoned destination collection instead of failing to move posts in" do
+          collection2.tombstone!
 
-          it "updates the note references" do
-            expect(note1.reload.model_id).to eq(@first_post.id)
-            expect(note1.reload.collection_id).to eq(nil)
-            expect(note2.reload.collection_id).to eq(collection1.id)
-          end
+          expect {
+            topic1.move_posts(user1, [post1.id, post3.id], destination_topic_id: topic2.id)
+          }.not_to raise_error
+          expect(DiscourseActivityPubCollection.all).to contain_exactly(collection1, collection2)
+          expect(collection2.reload).not_to be_tombstoned
+        end
+
+        it "moves the posts to a new non-ap topic, clearing their note collections" do
+          topic1.move_posts(
+            user1,
+            [post1.id, post3.id],
+            title: "New topic in another category",
+            category_id: category2.id,
+          )
+
+          new_topic = post3.reload.topic
+          expect(new_topic.category_id).to eq(category2.id)
+          expect(post2.reload.topic.category_id).to eq(category1.id)
+          expect(DiscourseActivityPubCollection.count).to eq(2)
+          expect(DiscourseActivityPubObject.count).to eq(3)
+          expect(DiscourseActivityPubActivity.count).to eq(3)
+          expect(note1.reload.model_id).to eq(new_topic.first_post.id)
+          expect(note1.collection_id).to eq(nil)
+          expect(note2.reload.collection_id).to eq(collection1.id)
+        end
+
+        it "moves the posts to an existing non-ap topic, clearing their note collections" do
+          topic1.move_posts(
+            user1,
+            [post1.id, post3.id],
+            destination_topic_id: topic3.id,
+            category_id: category2.id,
+          )
+
+          first_post = topic3.first_post.reload
+          expect(topic3.posts.size).to eq(2)
+          expect(first_post.raw).to eq(post1.raw)
+          expect(post2.reload.topic_id).to eq(topic1.id)
+          expect(post3.reload.topic_id).to eq(topic3.id)
+          expect(DiscourseActivityPubCollection.count).to eq(2)
+          expect(DiscourseActivityPubObject.count).to eq(3)
+          expect(DiscourseActivityPubActivity.count).to eq(3)
+          expect(note1.reload.model_id).to eq(first_post.id)
+          expect(note1.collection_id).to eq(nil)
+          expect(note2.reload.collection_id).to eq(collection1.id)
         end
       end
 
       context "with first_post enabled" do
         before { toggle_activity_pub(category1, publication_type: "first_post") }
 
-        context "when moved to a new first_post topic" do
-          before do
-            @new_topic =
-              topic1.move_posts(
-                user1,
-                [post1.id, post3.id],
-                title: "New topic in ap category",
-                category_id: category1.id,
-              )
-          end
-
-          it "moves the posts" do
-            expect([topic1.id, topic2.id, topic3.id]).to_not include(@new_topic.id)
-            expect(@new_topic.first_post.raw).to eq(post1.raw)
-            expect(post2.reload.topic.id).to eq(topic1.id)
-          end
-
-          it "does not create a collection for the new topic" do
-            expect(@new_topic.activity_pub_object).to eq(nil)
-          end
-
-          it "does not create new objects or activities" do
-            expect(DiscourseActivityPubObject.all.size).to eq(1)
-            expect(DiscourseActivityPubActivity.all.size).to eq(1)
-          end
-
-          it "updates the note references" do
-            expect(note1.reload.model_id).to eq(@new_topic.first_post.id)
-          end
-        end
-
-        context "when moved to an existing first_post topic" do
-          before do
-            topic1.move_posts(user1, [post1.id, post3.id], destination_topic_id: topic2.id)
-            @first_post = topic2.first_post
-          end
-
-          it "moves the posts" do
-            expect(topic2.posts.size).to eq(2)
-            expect(@first_post.raw).to eq(post1.raw)
-            expect(post2.reload.topic_id).to eq(topic1.id)
-            expect(post3.reload.topic_id).to eq(topic2.id)
-          end
-
-          it "does not create new objects or activities" do
-            expect(DiscourseActivityPubObject.all.size).to eq(1)
-            expect(DiscourseActivityPubActivity.all.size).to eq(1)
-          end
-
-          it "updates the note references" do
-            expect(note1.reload.model_id).to eq(@first_post.reload.id)
-          end
-        end
-
-        context "when moved to a new non-ap topic" do
-          before do
+        it "moves the posts to a new first_post topic without creating a collection" do
+          new_topic =
             topic1.move_posts(
               user1,
               [post1.id, post3.id],
-              title: "New topic in another category",
-              category_id: category2.id,
+              title: "New topic in ap category",
+              category_id: category1.id,
             )
-            @new_topic = post3.reload.topic
-            @first_post = @new_topic.first_post
-          end
 
-          it "moves the posts" do
-            expect(@new_topic.category_id).to eq(category2.id)
-            expect(post2.reload.topic.category_id).to eq(category1.id)
-            expect(post3.reload.topic.category_id).to eq(category2.id)
-          end
-
-          it "does not create new objects or activities" do
-            expect(DiscourseActivityPubObject.all.size).to eq(1)
-            expect(DiscourseActivityPubActivity.all.size).to eq(1)
-          end
-
-          it "updates the note references" do
-            expect(note1.reload.model_id).to eq(@first_post.id)
-          end
+          expect([topic1.id, topic2.id, topic3.id]).not_to include(new_topic.id)
+          expect(new_topic.first_post.raw).to eq(post1.raw)
+          expect(post2.reload.topic_id).to eq(topic1.id)
+          expect(new_topic.activity_pub_object).to eq(nil)
+          expect(DiscourseActivityPubObject.count).to eq(1)
+          expect(DiscourseActivityPubActivity.count).to eq(1)
+          expect(note1.reload.model_id).to eq(new_topic.first_post.id)
         end
 
-        context "when moved to an existing non-ap topic" do
-          before do
-            topic1.move_posts(
-              user1,
-              [post1.id, post3.id],
-              destination_topic_id: topic3.id,
-              category_id: category2.id,
-            )
-            @first_post = topic3.first_post
-          end
+        it "moves the posts to an existing first_post topic without creating records" do
+          topic1.move_posts(user1, [post1.id, post3.id], destination_topic_id: topic2.id)
 
-          it "moves the posts" do
-            expect(topic3.posts.size).to eq(2)
-            expect(@first_post.raw).to eq(post1.raw)
-            expect(post2.reload.topic_id).to eq(topic1.id)
-            expect(post3.reload.topic_id).to eq(topic3.id)
-          end
+          first_post = topic2.first_post
+          expect(topic2.posts.size).to eq(2)
+          expect(first_post.raw).to eq(post1.raw)
+          expect(post2.reload.topic_id).to eq(topic1.id)
+          expect(post3.reload.topic_id).to eq(topic2.id)
+          expect(DiscourseActivityPubObject.count).to eq(1)
+          expect(DiscourseActivityPubActivity.count).to eq(1)
+          expect(note1.reload.model_id).to eq(first_post.reload.id)
+        end
 
-          it "does not create new objects or activities" do
-            expect(DiscourseActivityPubObject.all.size).to eq(1)
-            expect(DiscourseActivityPubActivity.all.size).to eq(1)
-          end
+        it "moves the posts to a new non-ap topic" do
+          topic1.move_posts(
+            user1,
+            [post1.id, post3.id],
+            title: "New topic in another category",
+            category_id: category2.id,
+          )
 
-          it "updates the note references" do
-            expect(note1.reload.model_id).to eq(@first_post.id)
-          end
+          new_topic = post3.reload.topic
+          expect(new_topic.category_id).to eq(category2.id)
+          expect(post2.reload.topic.category_id).to eq(category1.id)
+          expect(DiscourseActivityPubObject.count).to eq(1)
+          expect(DiscourseActivityPubActivity.count).to eq(1)
+          expect(note1.reload.model_id).to eq(new_topic.first_post.id)
+        end
+
+        it "moves the posts to an existing non-ap topic" do
+          topic1.move_posts(
+            user1,
+            [post1.id, post3.id],
+            destination_topic_id: topic3.id,
+            category_id: category2.id,
+          )
+
+          first_post = topic3.first_post
+          expect(topic3.posts.size).to eq(2)
+          expect(first_post.raw).to eq(post1.raw)
+          expect(post2.reload.topic_id).to eq(topic1.id)
+          expect(post3.reload.topic_id).to eq(topic3.id)
+          expect(DiscourseActivityPubObject.count).to eq(1)
+          expect(DiscourseActivityPubActivity.count).to eq(1)
+          expect(note1.reload.model_id).to eq(first_post.id)
         end
       end
     end
 
     context "with posts in a non ap category" do
-      context "when moved to a new full_topic topic" do
-        before do
-          toggle_activity_pub(category2, publication_type: "full_topic")
-          @new_topic =
-            topic1.move_posts(
-              user1,
-              [post1.id, post3.id],
-              title: "New topic in ap category",
-              category_id: category2.id,
-            )
-        end
+      it "moves the posts to a new full_topic topic, creating a collection" do
+        toggle_activity_pub(category2, publication_type: "full_topic")
+        new_topic =
+          topic1.move_posts(
+            user1,
+            [post1.id, post3.id],
+            title: "New topic in ap category",
+            category_id: category2.id,
+          )
 
-        it "moves the posts" do
-          expect([topic1.id, topic2.id, topic3.id]).to_not include(@new_topic.id)
-          expect(@new_topic.first_post.raw).to eq(post1.raw)
-          expect(post2.reload.topic.id).to eq(topic1.id)
-        end
-
-        it "creates a collection for the new topic" do
-          expect(@new_topic.activity_pub_object&.ap&.collection?).to eq(true)
-        end
-
-        it "does not create new objects or activities" do
-          expect(DiscourseActivityPubObject.all.size).to eq(0)
-          expect(DiscourseActivityPubActivity.all.size).to eq(0)
-        end
+        expect([topic1.id, topic2.id, topic3.id]).not_to include(new_topic.id)
+        expect(new_topic.first_post.raw).to eq(post1.raw)
+        expect(post2.reload.topic_id).to eq(topic1.id)
+        expect(new_topic.activity_pub_object.ap.collection?).to eq(true)
+        expect(DiscourseActivityPubObject.count).to eq(0)
+        expect(DiscourseActivityPubActivity.count).to eq(0)
       end
 
-      context "when moved to an existing full_topic topic" do
-        let!(:collection1) { Fabricate(:discourse_activity_pub_ordered_collection, model: topic3) }
+      it "moves the posts to an existing full_topic topic without creating records" do
+        Fabricate(:discourse_activity_pub_ordered_collection, model: topic3)
+        toggle_activity_pub(category2, publication_type: "full_topic")
+        topic1.move_posts(user1, [post1.id, post3.id], destination_topic_id: topic3.id)
 
-        before do
-          toggle_activity_pub(category2, publication_type: "full_topic")
-          topic1.move_posts(user1, [post1.id, post3.id], destination_topic_id: topic3.id)
-          @first_post = topic3.first_post
-        end
-
-        it "moves the posts" do
-          expect(topic3.posts.size).to eq(2)
-          expect(@first_post.raw).to eq(post1.raw)
-          expect(post2.reload.topic_id).to eq(topic1.id)
-          expect(post3.reload.topic_id).to eq(topic3.id)
-        end
-
-        it "does not create new collections, objects or activities" do
-          expect(DiscourseActivityPubCollection.all.size).to eq(1)
-          expect(DiscourseActivityPubObject.all.size).to eq(0)
-          expect(DiscourseActivityPubActivity.all.size).to eq(0)
-        end
+        first_post = topic3.first_post
+        expect(topic3.posts.size).to eq(2)
+        expect(first_post.raw).to eq(post1.raw)
+        expect(post2.reload.topic_id).to eq(topic1.id)
+        expect(post3.reload.topic_id).to eq(topic3.id)
+        expect(DiscourseActivityPubCollection.count).to eq(1)
+        expect(DiscourseActivityPubObject.count).to eq(0)
+        expect(DiscourseActivityPubActivity.count).to eq(0)
       end
 
-      context "when moved to a new first_post topic" do
-        before do
-          toggle_activity_pub(category2, publication_type: "first_post")
-          @new_topic =
-            topic1.move_posts(
-              user1,
-              [post1.id, post3.id],
-              title: "New topic in ap category",
-              category_id: category2.id,
-            )
-        end
+      it "moves the posts to a new first_post topic without creating a collection" do
+        toggle_activity_pub(category2, publication_type: "first_post")
+        new_topic =
+          topic1.move_posts(
+            user1,
+            [post1.id, post3.id],
+            title: "New topic in ap category",
+            category_id: category2.id,
+          )
 
-        it "moves the posts" do
-          expect([topic1.id, topic2.id, topic3.id]).to_not include(@new_topic.id)
-          expect(@new_topic.first_post.raw).to eq(post1.raw)
-          expect(post2.reload.topic.id).to eq(topic1.id)
-        end
-
-        it "does not create a collection for the new topic" do
-          expect(@new_topic.activity_pub_object).to eq(nil)
-        end
-
-        it "does not create new objects or activities" do
-          expect(DiscourseActivityPubObject.all.size).to eq(0)
-          expect(DiscourseActivityPubActivity.all.size).to eq(0)
-        end
+        expect([topic1.id, topic2.id, topic3.id]).not_to include(new_topic.id)
+        expect(new_topic.first_post.raw).to eq(post1.raw)
+        expect(post2.reload.topic_id).to eq(topic1.id)
+        expect(new_topic.activity_pub_object).to eq(nil)
+        expect(DiscourseActivityPubObject.count).to eq(0)
+        expect(DiscourseActivityPubActivity.count).to eq(0)
       end
 
-      context "when moved to an existing first_post topic" do
-        before do
-          toggle_activity_pub(category2, publication_type: "first_post")
-          topic1.move_posts(user1, [post1.id, post3.id], destination_topic_id: topic3.id)
-          @first_post = topic3.first_post
-        end
+      it "moves the posts to an existing first_post topic without creating records" do
+        toggle_activity_pub(category2, publication_type: "first_post")
+        topic1.move_posts(user1, [post1.id, post3.id], destination_topic_id: topic3.id)
 
-        it "moves the posts" do
-          expect(topic3.posts.size).to eq(2)
-          expect(@first_post.raw).to eq(post1.raw)
-          expect(post2.reload.topic_id).to eq(topic1.id)
-          expect(post3.reload.topic_id).to eq(topic3.id)
-        end
-
-        it "does not create new collections, objects or activities" do
-          expect(DiscourseActivityPubCollection.all.size).to eq(0)
-          expect(DiscourseActivityPubObject.all.size).to eq(0)
-          expect(DiscourseActivityPubActivity.all.size).to eq(0)
-        end
+        first_post = topic3.first_post
+        expect(topic3.posts.size).to eq(2)
+        expect(first_post.raw).to eq(post1.raw)
+        expect(post2.reload.topic_id).to eq(topic1.id)
+        expect(post3.reload.topic_id).to eq(topic3.id)
+        expect(DiscourseActivityPubCollection.count).to eq(0)
+        expect(DiscourseActivityPubObject.count).to eq(0)
+        expect(DiscourseActivityPubActivity.count).to eq(0)
       end
     end
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -116,6 +116,18 @@ RSpec.describe Topic do
           end
         end
 
+        context "when the destination topic's collection was tombstoned" do
+          before { collection2.tombstone! }
+
+          it "revives it instead of failing to move posts in" do
+            expect {
+              topic1.move_posts(user1, [post1.id, post3.id], destination_topic_id: topic2.id)
+            }.not_to raise_error
+            expect(DiscourseActivityPubCollection.all).to contain_exactly(collection1, collection2)
+            expect(collection2.reload).not_to be_tombstoned
+          end
+        end
+
         context "when moved to a new non-ap topic" do
           before do
             topic1.move_posts(


### PR DESCRIPTION
### What

Moving one or more posts into a `full_topic` topic could raise
`ActiveRecord::RecordNotUnique` and surface to the user as an HTTP 500 — from
core's `TopicsController#move_posts`, which only rescues `RecordInvalid` /
`RecordNotSaved`, so anything else becomes a 500.

Reported on Meta: https://meta.discourse.org/t/error-500-when-moving-posts/397654

### Why

ActivityPub records are hidden once tombstoned, via `IdentifierValidations`'
`default_scope { where.not(ap_type: Tombstone.type) }`. The row still exists,
though, and still occupies the unique `(model_type, model_id)` index
(`unique_activity_pub_collection_models`).

The `:first_post_moved` / `:post_moved` handlers check
`!topic.activity_pub_object` — which the default scope reports as `nil` for a
tombstoned collection — and call `create_activity_pub_collection!`, which
blindly inserts a second collection for the same topic and collides on the
unique index.

It's data-dependent (the destination topic's collection must have been
tombstoned previously, e.g. via a delete/restore cycle), which matches the
intermittent, "no visible preconditions" reports.

### How

`create_activity_pub_collection!` now looks the collection up `unscoped`,
restores it when tombstoned, and reuses it instead of inserting a duplicate.
This makes the method idempotent for all of its callers, and preserves the
collection's `ap_id` (its federation identity) rather than orphaning it.

### Tests

- Adds a regression test for moving posts into a topic whose collection was
  tombstoned.
- A second commit simplifies the `move_posts` topic specs — collapsing the
  per-scenario example fan-out into one example each, with `:aggregate_failures`
  on the group. Same coverage, 38 → 14 examples, roughly half the runtime.
