### PR TITLE
SECURITY: WebFinger aliases expose restricted ActivityPub category URLs

### DIFF
--- a/lib/discourse_activity_pub/webfinger.rb
+++ b/lib/discourse_activity_pub/webfinger.rb
@@ -18,7 +18,9 @@ module DiscourseActivityPub
     end
 
     def find_actor(raw_handle)
-      DiscourseActivityPubActor.find_by_handle(raw_handle, local: true, types: [permitted_types])
+      actor =
+        DiscourseActivityPubActor.find_by_handle(raw_handle, local: true, types: [permitted_types])
+      actor if actor_visible?(actor)
     end
 
     def permitted_types
@@ -30,6 +32,14 @@ module DiscourseActivityPub
         types << DiscourseActivityPub::AP::Actor::Person.type
       end
       types
+    end
+
+    def actor_visible?(actor)
+      return false if actor.blank?
+      return true if actor.ap.application?
+      return false if actor.model.blank?
+
+      actor.ready? && ::Guardian.new(nil).can_see?(actor.model)
     end
 
     def self.resolve_handle(raw_handle)

--- a/lib/discourse_activity_pub/webfinger.rb
+++ b/lib/discourse_activity_pub/webfinger.rb
@@ -39,7 +39,7 @@ module DiscourseActivityPub
       return true if actor.ap.application?
       return false if actor.model.blank?
 
-      actor.ready? && ::Guardian.new(nil).can_see?(actor.model)
+      actor.ready? && ::Guardian.new.can_see?(actor.model)
     end
 
     def self.resolve_handle(raw_handle)

--- a/spec/requests/discourse_activity_pub/webfinger_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/webfinger_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DiscourseActivityPub::WebfingerController do
       before { SiteSetting.activity_pub_enabled = false }
 
       it "returns a not enabled error" do
-        get "/.well-known/webfinger"
+        get "/.well-known/webfinger", headers: { "Accept" => "application/json" }
         expect(response.status).to eq(404)
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe DiscourseActivityPub::WebfingerController do
       end
 
       context "with a supported scheme" do
-        let!(:group) { Fabricate(:discourse_activity_pub_actor_group, domain: nil) }
+        let!(:group) { Fabricate(:discourse_activity_pub_actor_group, domain: nil, enabled: true) }
         let!(:person) { Fabricate(:discourse_activity_pub_actor_person, domain: nil) }
 
         context "when the domain is incorrect" do
@@ -55,6 +55,38 @@ RSpec.describe DiscourseActivityPub::WebfingerController do
             expect(body["subject"]).to eq("acct:#{group.username}@#{DiscourseActivityPub.host}")
             expect(body["aliases"]).to eq(group.webfinger_aliases)
             expect(body["links"]).to eq(group.webfinger_links.map(&:as_json))
+          end
+        end
+
+        context "when the actor model is read restricted" do
+          it "returns a not found error without disclosing the actor URLs" do
+            restricted_category = Fabricate(:category)
+            toggle_activity_pub(restricted_category)
+            restricted_category.set_permissions(staff: :full)
+            restricted_category.save!
+            restricted_actor = restricted_category.reload.activity_pub_actor
+
+            get "/.well-known/webfinger?resource=acct:#{restricted_actor.username}@#{DiscourseActivityPub.host}"
+
+            expect(response.status).to eq(400)
+            expect(response.parsed_body).to eq(build_error("resource_not_found"))
+            expect(response.body).not_to include(restricted_category.activity_pub_url)
+            expect(response.body).not_to include(restricted_actor.ap_id)
+          end
+        end
+
+        context "when the actor is disabled" do
+          it "returns a not found error without disclosing the actor URLs" do
+            disabled_category = Fabricate(:category)
+            toggle_activity_pub(disabled_category, disable: true)
+            disabled_actor = disabled_category.reload.activity_pub_actor
+
+            get "/.well-known/webfinger?resource=acct:#{disabled_actor.username}@#{DiscourseActivityPub.host}"
+
+            expect(response.status).to eq(400)
+            expect(response.parsed_body).to eq(build_error("resource_not_found"))
+            expect(response.body).not_to include(disabled_category.activity_pub_url)
+            expect(response.body).not_to include(disabled_actor.ap_id)
           end
         end
 


### PR DESCRIPTION
## Summary

Prevent ActivityPub WebFinger from disclosing actor metadata, such as category URLs and actor IDs, for read-restricted or disabled categories. The lookup logic now verifies that model-backed actors are publicly visible and ready before returning aliases or links.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1233
- Affected file: https://github.com/discourse/discourse-activity-pub/blob/main/app/serializers/discourse_activity_pub/webfinger_serializer.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>