### PR TITLE
SECURITY: Detailed actor cards expose hidden tag model data on the public ActivityPub about endpoint

### DIFF
--- a/app/serializers/discourse_activity_pub/about_serializer.rb
+++ b/app/serializers/discourse_activity_pub/about_serializer.rb
@@ -11,9 +11,11 @@ module DiscourseActivityPub
     end
 
     def tag_actors
-      object.tag_actors.map do |actor|
-        DiscourseActivityPub::CardActorSerializer.new(actor, root: false, scope: scope).as_json
-      end
+      object
+        .tag_actors(scope)
+        .map do |actor|
+          DiscourseActivityPub::CardActorSerializer.new(actor, root: false, scope: scope).as_json
+        end
     end
   end
 end

--- a/app/serializers/discourse_activity_pub/detailed_actor_serializer.rb
+++ b/app/serializers/discourse_activity_pub/detailed_actor_serializer.rb
@@ -5,13 +5,15 @@ module DiscourseActivityPub
     attributes :local, :url, :icon_url, :followed_at, :model
 
     def model
+      return nil unless scope&.can_see?(object.model)
+
       case object.model_type
       when "User"
-        BasicUserSerializer.new(object.model, root: false).as_json
+        BasicUserSerializer.new(object.model, root: false, scope: scope).as_json
       when "Category"
-        SiteCategorySerializer.new(object.model, root: false).as_json
+        SiteCategorySerializer.new(object.model, root: false, scope: scope).as_json
       when "Tag"
-        TagSerializer.new(object.model, root: false).as_json
+        TagSerializer.new(object.model, root: false, scope: scope).as_json
       end
     end
   end

--- a/lib/discourse_activity_pub/about.rb
+++ b/lib/discourse_activity_pub/about.rb
@@ -14,9 +14,11 @@ module DiscourseActivityPub
         actors.where(model_type: "Category").order("COUNT(discourse_activity_pub_actors.id) DESC")
     end
 
-    def tag_actors
-      @tags ||=
-        actors.where(model_type: "Tag").order("COUNT(discourse_activity_pub_actors.id) DESC")
+    def tag_actors(guardian = nil)
+      actors.where(
+        model_type: "Tag",
+        model_id: DiscourseTagging.visible_tags(guardian).select(:id),
+      ).order("COUNT(discourse_activity_pub_actors.id) DESC")
     end
   end
 end

--- a/spec/requests/discourse_activity_pub/about_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/about_controller_spec.rb
@@ -79,6 +79,22 @@ RSpec.describe DiscourseActivityPub::AboutController do
           expect(response.parsed_body["category_actors"].size).to eq(2)
           expect(response.parsed_body["tag_actors"].size).to eq(1)
         end
+
+        it "does not return hidden tag actors" do
+          hidden_tag = Fabricate(:tag, name: "staff-only")
+          hidden_tag_actor =
+            Fabricate(:discourse_activity_pub_actor_group, model: hidden_tag, local: true)
+          Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
+          toggle_activity_pub(hidden_tag)
+
+          get "/ap/about.json"
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["tag_actors"].map { |actor| actor["id"] }).not_to include(
+            hidden_tag_actor.id,
+          )
+          expect(response.body).not_to include(hidden_tag.name)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Prevent information disclosure of restricted tags, categories, and users by enforcing visibility checks in the ActivityPub about endpoint and detailed actor serializers. This fix ensures that hidden actors are excluded from public listings and that nested model data is only serialized when the requester has sufficient permissions.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1232
- Affected file: https://github.com/discourse/discourse-activity-pub/blob/main/app/serializers/discourse_activity_pub/detailed_actor_serializer.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>