### PR TITLE
SECURITY: ActivityPub topic publish bypass exposes restricted topic titles through tag outboxes

### DIFF
--- a/app/controllers/discourse_activity_pub/topic_controller.rb
+++ b/app/controllers/discourse_activity_pub/topic_controller.rb
@@ -9,6 +9,7 @@ module DiscourseActivityPub
     before_action :ensure_site_enabled
     before_action :ensure_staff
     before_action :find_topic
+    before_action :ensure_can_see_topic
     before_action :ensure_can_publish
 
     def publish
@@ -19,10 +20,14 @@ module DiscourseActivityPub
     protected
 
     def ensure_can_publish
-      if !@topic.activity_pub_full_topic || @topic.activity_pub_all_posts_published? ||
+      if !@topic.activity_pub_publishable? || @topic.activity_pub_all_posts_published? ||
            @topic.activity_pub_scheduled?
         render_topic_error("cant_publish_topic", 422)
       end
+    end
+
+    def ensure_can_see_topic
+      render_topic_error("topic_not_found", 400) if !guardian.can_see?(@topic)
     end
 
     def find_topic

--- a/app/models/discourse_activity_pub/topic.rb
+++ b/app/models/discourse_activity_pub/topic.rb
@@ -70,6 +70,10 @@ module DiscourseActivityPub::Topic
     activity_pub_enabled && activity_pub_full_topic
   end
 
+  def activity_pub_publishable?
+    activity_pub_enabled && activity_pub_ready? && activity_pub_full_topic_enabled
+  end
+
   def create_activity_pub_collection!
     if existing = DiscourseActivityPubCollection.unscoped.find_by(model: self)
       existing.restore_tombstoned! if existing.tombstoned?
@@ -103,7 +107,7 @@ module DiscourseActivityPub::Topic
   end
 
   def activity_pub_publish!
-    return false if activity_pub_published?
+    return false if activity_pub_published? || !activity_pub_publishable?
     Jobs.enqueue(Jobs::DiscourseActivityPub::Publish, topic_id: self.id)
   end
 

--- a/app/models/discourse_activity_pub_actor.rb
+++ b/app/models/discourse_activity_pub_actor.rb
@@ -191,10 +191,32 @@ class DiscourseActivityPubActor < ActiveRecord::Base
             updated_at: self.updated_at,
             summary: I18n.t("discourse_activity_pub.actor.outbox.summary", actor: username),
           )
-        collection.items = activities
+        collection.items = publishable_outbox_activities
         collection.context = :outbox
         collection
       end
+  end
+
+  def publishable_outbox_activities
+    activities.select { |activity| outbox_activity_publishable?(activity) }
+  end
+
+  def outbox_activity_publishable?(activity)
+    model = outbox_activity_model(activity)
+
+    case model
+    when ::Post
+      model.activity_pub_enabled
+    when ::Topic
+      model.activity_pub_publishable?
+    else
+      true
+    end
+  end
+
+  def outbox_activity_model(activity)
+    base_object = activity.base_object
+    base_object.model if base_object.respond_to?(:model)
   end
 
   def shared_inbox

--- a/app/serializers/discourse_activity_pub/about_serializer.rb
+++ b/app/serializers/discourse_activity_pub/about_serializer.rb
@@ -5,9 +5,11 @@ module DiscourseActivityPub
     attributes :category_actors, :tag_actors
 
     def category_actors
-      object.category_actors(scope).map do |actor|
-        DiscourseActivityPub::CardActorSerializer.new(actor, root: false, scope: scope).as_json
-      end
+      object
+        .category_actors(scope)
+        .map do |actor|
+          DiscourseActivityPub::CardActorSerializer.new(actor, root: false, scope: scope).as_json
+        end
     end
 
     def tag_actors

--- a/app/serializers/discourse_activity_pub/about_serializer.rb
+++ b/app/serializers/discourse_activity_pub/about_serializer.rb
@@ -5,7 +5,7 @@ module DiscourseActivityPub
     attributes :category_actors, :tag_actors
 
     def category_actors
-      object.category_actors.map do |actor|
+      object.category_actors(scope).map do |actor|
         DiscourseActivityPub::CardActorSerializer.new(actor, root: false, scope: scope).as_json
       end
     end

--- a/lib/discourse_activity_pub/about.rb
+++ b/lib/discourse_activity_pub/about.rb
@@ -9,9 +9,11 @@ module DiscourseActivityPub
         DiscourseActivityPubActor.local.active.includes(:model).group(:id).left_joins(:followers)
     end
 
-    def category_actors
+    def category_actors(guardian = nil)
       @categories ||=
-        actors.where(model_type: "Category").order("COUNT(discourse_activity_pub_actors.id) DESC")
+        actors
+          .where(model_type: "Category", model_id: Category.secured(guardian).select(:id))
+          .order("COUNT(discourse_activity_pub_actors.id) DESC")
     end
 
     def tag_actors(guardian = nil)

--- a/lib/discourse_activity_pub/about.rb
+++ b/lib/discourse_activity_pub/about.rb
@@ -11,9 +11,10 @@ module DiscourseActivityPub
 
     def category_actors(guardian = nil)
       @categories ||=
-        actors
-          .where(model_type: "Category", model_id: Category.secured(guardian).select(:id))
-          .order("COUNT(discourse_activity_pub_actors.id) DESC")
+        actors.where(
+          model_type: "Category",
+          model_id: Category.secured(guardian).select(:id),
+        ).order("COUNT(discourse_activity_pub_actors.id) DESC")
     end
 
     def tag_actors(guardian = nil)

--- a/lib/discourse_activity_pub/bulk/publish.rb
+++ b/lib/discourse_activity_pub/bulk/publish.rb
@@ -17,6 +17,7 @@ module DiscourseActivityPub
         log_started
 
         return log_publish_failed("actor_not_found") if !actor
+        return log_publish_failed("actor_not_ready") if topic && !topic.activity_pub_publishable?
         return log_publish_failed("actor_not_ready") if !actor&.ready?
         if !DiscourseActivityPubActor::GROUP_MODELS.map(&:downcase).include?(
              actor.model_type.downcase,

--- a/spec/lib/discourse_activity_pub/bulk/publish_spec.rb
+++ b/spec/lib/discourse_activity_pub/bulk/publish_spec.rb
@@ -851,6 +851,22 @@ RSpec.describe DiscourseActivityPub::Bulk::Publish do
     end
 
     context "with a topic" do
+      it "does not create ActivityPub records for a topic that is no longer publishable" do
+        tag = Fabricate(:tag)
+        restricted_category = Fabricate(:category)
+        restricted_topic = Fabricate(:topic, category: restricted_category, tags: [tag])
+        Fabricate(:post, topic: restricted_topic, post_number: 1)
+        Fabricate(:post, topic: restricted_topic, post_number: 2)
+
+        toggle_activity_pub(tag, publication_type: "full_topic")
+        restricted_category.update!(read_restricted: true)
+
+        described_class.perform(topic_id: restricted_topic.id)
+
+        expect(restricted_topic.reload.activity_pub_object).to eq(nil)
+        expect(::Post.where(topic: restricted_topic).any?(&:activity_pub_published?)).to eq(false)
+      end
+
       context "with full topic enabled" do
         before { toggle_activity_pub(category, publication_type: "full_topic") }
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -281,4 +281,13 @@ RSpec.describe Topic do
       end
     end
   end
+
+  describe "#activity_pub_publish!" do
+    it "returns false without publishing posts when the topic is not full-topic publishable" do
+      toggle_activity_pub(category1, publication_type: "first_post")
+
+      expect(topic1.reload.activity_pub_publish!).to eq(false)
+      expect(post1.reload.activity_pub_published?).to eq(false)
+    end
+  end
 end

--- a/spec/requests/discourse_activity_pub/about_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/about_controller_spec.rb
@@ -80,6 +80,21 @@ RSpec.describe DiscourseActivityPub::AboutController do
           expect(response.parsed_body["tag_actors"].size).to eq(1)
         end
 
+        it "does not return stale enabled category actors that are no longer ActivityPub-ready" do
+          private_description = "Private ActivityPub category description"
+          category1.update_column(:description, private_description)
+          toggle_activity_pub(category1)
+          category1.set_permissions(staff: :full)
+          category1.save!
+          category_actor_1.update!(enabled: true)
+
+          get "/ap/about.json"
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["category_actors"]).to eq([])
+          expect(response.body).not_to include(category1.description_text)
+        end
+
         it "does not return hidden tag actors" do
           hidden_tag = Fabricate(:tag, name: "staff-only")
           hidden_tag_actor =

--- a/spec/requests/discourse_activity_pub/ap/outboxes_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/outboxes_controller_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe DiscourseActivityPub::AP::OutboxesController do
     it "omits activities whose base object is no longer publishable" do
       tag = Fabricate(:tag)
       category = Fabricate(:category)
-      topic = Fabricate(:topic, category: category, tags: [tag], title: "Restricted ActivityPub Topic")
+      topic =
+        Fabricate(:topic, category: category, tags: [tag], title: "Restricted ActivityPub Topic")
       Fabricate(:post, topic: topic, post_number: 1)
       Fabricate(:post, topic: topic, post_number: 2)
 

--- a/spec/requests/discourse_activity_pub/ap/outboxes_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/outboxes_controller_spec.rb
@@ -27,5 +27,23 @@ RSpec.describe DiscourseActivityPub::AP::OutboxesController do
       expect(parsed_body["orderedItems"][1]["id"]).to eq(activity1.ap_id)
       expect(parsed_body["orderedItems"][2]["id"]).to eq(activity2.ap_id)
     end
+
+    it "omits activities whose base object is no longer publishable" do
+      tag = Fabricate(:tag)
+      category = Fabricate(:category)
+      topic = Fabricate(:topic, category: category, tags: [tag], title: "Restricted ActivityPub Topic")
+      Fabricate(:post, topic: topic, post_number: 1)
+      Fabricate(:post, topic: topic, post_number: 2)
+
+      toggle_activity_pub(tag, publication_type: "full_topic")
+      DiscourseActivityPub::Bulk::Publish.perform(topic_id: topic.id)
+      category.update!(read_restricted: true)
+
+      get_from_outbox(tag.activity_pub_actor.reload)
+
+      expect(response.status).to eq(200)
+      expect(parsed_body["totalItems"]).to eq(0)
+      expect(response.body).not_to include(topic.title)
+    end
   end
 end

--- a/spec/requests/discourse_activity_pub/topic_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/topic_controller_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe DiscourseActivityPub::TopicController do
         end
 
         context "with a valid topic id" do
+          it "does not publish a topic the staff user cannot see" do
+            group = Fabricate(:group)
+            restricted_category = Fabricate(:category)
+            restricted_category.set_permissions(group => :full)
+            restricted_category.save!
+            tag = Fabricate(:tag)
+            restricted_topic = Fabricate(:topic, category: restricted_category, tags: [tag])
+            Fabricate(:post, topic: restricted_topic, post_number: 1)
+            Fabricate(:post, topic: restricted_topic, post_number: 2)
+
+            toggle_activity_pub(tag, publication_type: "full_topic")
+
+            post "/ap/topic/publish/#{restricted_topic.id}"
+
+            expect(response.status).to eq(400)
+            expect(response.parsed_body).to eq(build_error("topic_not_found"))
+            expect(restricted_topic.reload.activity_pub_object).to eq(nil)
+          end
+
           context "with a first_post activity pub category" do
             before { toggle_activity_pub(category, publication_type: "first_post") }
 


### PR DESCRIPTION
## Summary

Prevent the exposure of restricted topic metadata through ActivityPub by enforcing visibility and readiness checks during publication and outbox serialization. Correctly omit activities from actor outboxes when the underlying topic or post is no longer publishable or visible.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1225
- Affected file: https://github.com/discourse/discourse-activity-pub/blob/main/app/models/discourse_activity_pub/topic.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>