### PR TITLE
SECURITY: Add OAuth state to Mastodon account verification

### DIFF
--- a/app/controllers/discourse_activity_pub/authorization_controller.rb
+++ b/app/controllers/discourse_activity_pub/authorization_controller.rb
@@ -4,6 +4,7 @@ module DiscourseActivityPub
   class AuthorizationController < ApplicationController
     DOMAIN_SESSION_KEY = "activity_pub_authorize_domain"
     AUTHORIZATION_SESSION_KEY = "activity_pub_authorize_id"
+    STATE_SESSION_KEY = "activity_pub_authorize_state"
     SESSION_EXPIRY_MINUTES = 10
     SUPPORTED_AUTH_TYPES = %i[mastodon]
 
@@ -23,6 +24,7 @@ module DiscourseActivityPub
 
     rescue_from DiscourseActivityPub::AuthFailed do |e|
       @authorization&.destroy!
+      clear_authorization_session
       redirect_to "/u/#{current_user.username}/preferences/activity-pub?error=#{CGI.escape(e.message)}"
     end
 
@@ -46,12 +48,16 @@ module DiscourseActivityPub
     end
 
     def authorize
+      state = SecureRandom.hex(32)
       set_session_value(AUTHORIZATION_SESSION_KEY, @authorization.id)
+      set_session_value(STATE_SESSION_KEY, state)
+      auth_handler.state = state
 
       authorize_url = auth_handler.get_authorize_url
       if authorize_url
         redirect_to authorize_url, allow_other_host: true
       else
+        clear_authorization_session
         render_auth_error("invalid_domain", 404)
       end
     end
@@ -59,6 +65,7 @@ module DiscourseActivityPub
     def redirect
       ensure_authorization_session
       ensure_authorization
+      ensure_authorization_state
 
       @authorization.token = auth_handler.get_token(redirect_params)
       raise_auth_failed unless @authorization.token
@@ -85,6 +92,7 @@ module DiscourseActivityPub
         )
       end
 
+      clear_authorization_session
       redirect_to "/u/#{current_user.username}/preferences/activity-pub"
     end
 
@@ -126,7 +134,10 @@ module DiscourseActivityPub
     def validate_auth_type
       params.require(:auth_type)
       @auth_type = params[:auth_type].to_sym
-      raise ::Discourse::InvalidParameters if SUPPORTED_AUTH_TYPES.exclude?(@auth_type)
+      if SUPPORTED_AUTH_TYPES.exclude?(@auth_type)
+        clear_authorization_session if action_name == "redirect"
+        raise ::Discourse::InvalidParameters
+      end
     end
 
     def validate_domain
@@ -169,6 +180,7 @@ module DiscourseActivityPub
     def ensure_authorization_session
       @auth_id = get_session_value(AUTHORIZATION_SESSION_KEY)
       unless @auth_id
+        clear_authorization_session
         raise ::Discourse::InvalidAccess.new(
                 I18n.t("discourse_activity_pub.auth.error.session_expired"),
               )
@@ -176,16 +188,37 @@ module DiscourseActivityPub
     end
 
     def ensure_authorization
-      @authorization = DiscourseActivityPubAuthorization.find_by(id: @auth_id)
+      @authorization =
+        DiscourseActivityPubAuthorization.find_by(id: @auth_id, user_id: current_user.id)
       unless @authorization
+        clear_authorization_session
         raise ::Discourse::InvalidAccess.new(
                 I18n.t("discourse_activity_pub.auth.error.authorization_required"),
               )
       end
       @auth_type = @authorization.client.auth_type_name
-      raise ::Discourse::InvalidParameters if SUPPORTED_AUTH_TYPES.exclude?(@auth_type)
+      if SUPPORTED_AUTH_TYPES.exclude?(@auth_type)
+        clear_authorization_session
+        raise ::Discourse::InvalidParameters
+      end
       @domain = @authorization.client.domain
       auth_handler.auth_id = @authorization.id
+    end
+
+    def ensure_authorization_state
+      expected_state = get_session_value(STATE_SESSION_KEY)
+      state = params[:state].to_s
+      state_matches =
+        expected_state.present? && state.present? && state.bytesize == expected_state.bytesize &&
+          ActiveSupport::SecurityUtils.secure_compare(state, expected_state)
+
+      raise_invalid_redirect_params unless state_matches
+    end
+
+    def raise_invalid_redirect_params
+      raise DiscourseActivityPub::AuthFailed.new(
+              I18n.t("discourse_activity_pub.auth.error.invalid_redirect_params"),
+            )
     end
 
     def get_session_value(key)
@@ -194,6 +227,11 @@ module DiscourseActivityPub
 
     def set_session_value(key, value)
       server_session.set(key, value, expires: SESSION_EXPIRY_MINUTES.minutes)
+    end
+
+    def clear_authorization_session
+      server_session.delete(AUTHORIZATION_SESSION_KEY)
+      server_session.delete(STATE_SESSION_KEY)
     end
 
     def redirect_params

--- a/lib/discourse_activity_pub/auth.rb
+++ b/lib/discourse_activity_pub/auth.rb
@@ -8,7 +8,7 @@ module DiscourseActivityPub
     TIMEOUT = 30
 
     attr_reader :domain
-    attr_accessor :auth_id
+    attr_accessor :auth_id, :state
 
     def initialize(domain: nil)
       @domain = domain

--- a/lib/discourse_activity_pub/auth/mastodon.rb
+++ b/lib/discourse_activity_pub/auth/mastodon.rb
@@ -68,15 +68,17 @@ module DiscourseActivityPub
 
         return nil unless auth_scopes
 
+        params = {
+          client_id: client.credentials["client_id"],
+          response_type: "code",
+          redirect_uri: "#{DiscourseActivityPub.base_url}/#{REDIRECT_PATH}",
+          scope: auth_scopes,
+          force_login: true,
+        }
+        params[:state] = state if state.present?
+
         uri = DiscourseActivityPub::URI.parse("https://#{domain}/#{AUTHORIZE_PATH}")
-        uri.query =
-          ::URI.encode_www_form(
-            client_id: client.credentials["client_id"],
-            response_type: "code",
-            redirect_uri: "#{DiscourseActivityPub.base_url}/#{REDIRECT_PATH}",
-            scope: auth_scopes,
-            force_login: true,
-          )
+        uri.query = ::URI.encode_www_form(params)
         uri.to_s
       end
 

--- a/spec/requests/discourse_activity_pub/authorization_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/authorization_controller_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe DiscourseActivityPub::AuthorizationController do
   let!(:mastodon_access_token) { "ZA-Yj3aBD8U8Cm7lKUp-lm9O9BmDgdhHzDeqsY8tlL0" }
   let!(:mastodon_code) { "123456" }
   let!(:mastodon_client_access_token) { "BA-Yj3aBD8U8Cm7lKUp-lm9O9BmDgdhHzDeqsY8tlL0" }
+  let(:authorization_state_session_key) { "activity_pub_authorize_state" }
   let!(:mastodon_app_json) do
     {
       id: "563419",
@@ -242,10 +243,13 @@ RSpec.describe DiscourseActivityPub::AuthorizationController do
             )
           end
 
-          it "redirects to the authorize url for the app" do
+          it "redirects to the authorize url with state" do
             get "/ap/auth/authorize/mastodon", params: { domain: external_domain1 }
+
+            state = server_session[authorization_state_session_key]
+            expect(state).to match(/\A[0-9a-f]{64}\z/)
             expect(response).to redirect_to(
-              DiscourseActivityPub::Auth::Mastodon.get_authorize_url(external_domain1),
+              "#{DiscourseActivityPub::Auth::Mastodon.get_authorize_url(external_domain1)}&state=#{state}",
             )
           end
         end
@@ -278,18 +282,83 @@ RSpec.describe DiscourseActivityPub::AuthorizationController do
     end
 
     context "with an authorization id in the session" do
-      let!(:authorization) { Fabricate(:discourse_activity_pub_authorization_mastodon, user: user) }
+      let!(:authorization) do
+        Fabricate(:discourse_activity_pub_authorization_mastodon, user: user, actor: nil)
+      end
+      let(:oauth_state) { "oauth-state" }
+      let(:valid_redirect_params) { { code: mastodon_code, state: oauth_state } }
 
       before do
         server_session[
           DiscourseActivityPub::AuthorizationController::AUTHORIZATION_SESSION_KEY
         ] = authorization.id
+        server_session[authorization_state_session_key] = oauth_state
+      end
+
+      context "with another user's authorization id" do
+        let!(:other_user) { Fabricate(:user) }
+        let!(:authorization) do
+          Fabricate(:discourse_activity_pub_authorization_mastodon, user: other_user, actor: nil)
+        end
+        let!(:actor) { Fabricate(:discourse_activity_pub_actor_person, ap_id: external_actor_id) }
+
+        before do
+          DiscourseActivityPub::Auth::Mastodon
+            .any_instance
+            .stubs(:get_token)
+            .with({ code: mastodon_code })
+            .returns(mastodon_access_token)
+          DiscourseActivityPub::Auth::Mastodon
+            .any_instance
+            .stubs(:get_actor_ap_id)
+            .with(mastodon_access_token)
+            .returns(external_actor_id)
+        end
+
+        it "raises an invalid access error and clears the session" do
+          get "/ap/auth/redirect/mastodon", params: valid_redirect_params
+
+          expect(response.status).to eq(403)
+          expect(DiscourseActivityPubAuthorization.exists?(authorization.id)).to eq(true)
+          expect(server_session[described_class::AUTHORIZATION_SESSION_KEY]).to eq(nil)
+          expect(server_session[authorization_state_session_key]).to eq(nil)
+        end
       end
 
       context "with mastodon" do
+        context "with a mismatched state param" do
+          let!(:actor) { Fabricate(:discourse_activity_pub_actor_person, ap_id: external_actor_id) }
+
+          before do
+            DiscourseActivityPub::Auth::Mastodon
+              .any_instance
+              .stubs(:get_token)
+              .with({ code: mastodon_code })
+              .returns(mastodon_access_token)
+            DiscourseActivityPub::Auth::Mastodon
+              .any_instance
+              .stubs(:get_actor_ap_id)
+              .with(mastodon_access_token)
+              .returns(external_actor_id)
+          end
+
+          it "rejects the redirect and clears the session" do
+            get "/ap/auth/redirect/mastodon", params: { code: mastodon_code, state: "wrong-state" }
+
+            message =
+              CGI.escape(I18n.t("discourse_activity_pub.auth.error.invalid_redirect_params"))
+            expect(response).to redirect_to(
+              "/u/#{user.username}/preferences/activity-pub?error=#{message}",
+            )
+            expect(DiscourseActivityPubAuthorization.exists?(authorization.id)).to eq(false)
+            expect(server_session[described_class::AUTHORIZATION_SESSION_KEY]).to eq(nil)
+            expect(server_session[authorization_state_session_key]).to eq(nil)
+          end
+        end
+
         context "without a code param" do
           it "redirects to the current user's activity pub settings with the right error" do
-            get "/ap/auth/redirect/mastodon"
+            get "/ap/auth/redirect/mastodon", params: { state: oauth_state }
             message = CGI.escape("Invalid redirect params")
             expect(response).to redirect_to(
               "/u/#{user.username}/preferences/activity-pub?error=#{message}",
@@ -306,7 +375,7 @@ RSpec.describe DiscourseActivityPub::AuthorizationController do
           end
 
           it "redirects to the current user's activity pub settings with the right error" do
-            get "/ap/auth/redirect/mastodon", params: { code: mastodon_code }
+            get "/ap/auth/redirect/mastodon", params: valid_redirect_params
             message = CGI.escape("Failed to get token")
             expect(response).to redirect_to(
               "/u/#{user.username}/preferences/activity-pub?error=#{message}",
@@ -337,12 +406,12 @@ RSpec.describe DiscourseActivityPub::AuthorizationController do
             end
 
             it "adds the token to the authorization" do
-              get "/ap/auth/redirect/mastodon", params: { code: mastodon_code }
+              get "/ap/auth/redirect/mastodon", params: valid_redirect_params
               expect(authorization.reload.token).to eq(mastodon_access_token)
             end
 
             it "adds the actor to the authorization" do
-              get "/ap/auth/redirect/mastodon", params: { code: mastodon_code }
+              get "/ap/auth/redirect/mastodon", params: valid_redirect_params
               expect(authorization.reload.actor.ap_id).to eq(external_actor_id)
             end
 
@@ -354,15 +423,17 @@ RSpec.describe DiscourseActivityPub::AuthorizationController do
               end
 
               it "enqueues a job to merge the existing user into the current user" do
-                get "/ap/auth/redirect/mastodon", params: { code: mastodon_code }
+                get "/ap/auth/redirect/mastodon", params: valid_redirect_params
                 args = { user_id: user2.id, target_user_id: user.id, current_user_id: user.id }
                 expect(job_enqueued?(job: :merge_user, args: args)).to eq(true)
               end
             end
 
             it "redirects to the current user's activity pub settings" do
-              get "/ap/auth/redirect/mastodon", params: { code: mastodon_code }
+              get "/ap/auth/redirect/mastodon", params: valid_redirect_params
               expect(response).to redirect_to("/u/#{user.username}/preferences/activity-pub")
+              expect(server_session[described_class::AUTHORIZATION_SESSION_KEY]).to eq(nil)
+              expect(server_session[authorization_state_session_key]).to eq(nil)
             end
           end
 
@@ -376,7 +447,7 @@ RSpec.describe DiscourseActivityPub::AuthorizationController do
             end
 
             it "redirects to the current user's activity pub settings with the right error" do
-              get "/ap/auth/redirect/mastodon", params: { code: mastodon_code }
+              get "/ap/auth/redirect/mastodon", params: valid_redirect_params
               message = CGI.escape("Failed to get actor")
               expect(response).to redirect_to(
                 "/u/#{user.username}/preferences/activity-pub?error=#{message}",
@@ -387,9 +458,11 @@ RSpec.describe DiscourseActivityPub::AuthorizationController do
       end
 
       context "with discourse" do
-        it "raises an invalid parameters error" do
+        it "raises an invalid parameters error and clears the session" do
           get "/ap/auth/redirect/discourse"
           expect(response.status).to eq(400)
+          expect(server_session[described_class::AUTHORIZATION_SESSION_KEY]).to eq(nil)
+          expect(server_session[authorization_state_session_key]).to eq(nil)
         end
       end
     end


### PR DESCRIPTION
## Summary

Strengthen OAuth state validation in ActivityPub Mastodon authorization to prevent attackers from binding their actors to other users' accounts. The patch ensures a unique state is generated and verified during the redirect flow, while also scoping authorization lookups to the signed-in user and ensuring session data is cleared after use.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1406
- Affected file: https://github.com/discourse/discourse-activity-pub/blob/main/app/controllers/discourse_activity_pub/authorization_controller.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>