### PR TITLE
SECURITY: HTTP Signature keyId can bind an attacker key to any remote actor

### DIFF
--- a/app/controllers/concerns/discourse_activity_pub/signature_verification.rb
+++ b/app/controllers/concerns/discourse_activity_pub/signature_verification.rb
@@ -242,12 +242,32 @@ module DiscourseActivityPub
         actor = DiscourseActivityPubActor.find_by(ap_id: ap_id)
 
         if !actor
-          ap_actor = AP::Actor.resolve_and_store(ap_id)
-          actor = ap_actor.stored if ap_actor
+          ap_actor = AP::Actor.resolve(ap_id)
+          if resolved_actor_matches_key_id_actor?(ap_actor, ap_id)
+            ap_actor.apply_handlers(ap_actor.type, :store)
+            actor = ap_actor.stored
+          end
         end
       end
 
+      return unless actor
+
+      unless domain_allowed?(DiscourseActivityPub::URI.domain_from_uri(actor.ap_id))
+        @signature_verification_failure_code = 403
+        return
+      end
+
       actor
+    end
+
+    def resolved_actor_matches_key_id_actor?(ap_actor, ap_id)
+      return false if !ap_actor || ap_actor.id != ap_id
+
+      public_key = ap_actor.json["publicKey"]
+      return true if public_key.blank?
+
+      public_key.is_a?(Hash) && public_key["owner"] == ap_id &&
+        public_key["id"].to_s.split("#").first == ap_id
     end
   end
 end

--- a/spec/requests/discourse_activity_pub/ap/inboxes_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/inboxes_controller_spec.rb
@@ -326,6 +326,40 @@ RSpec.describe DiscourseActivityPub::AP::InboxesController do
           end
         end
 
+        context "with a keyId URL that resolves to a different actor" do
+          before do
+            setup_logging
+            SiteSetting.activity_pub_allowed_request_origins = "remote.com"
+          end
+
+          after { teardown_logging }
+
+          it "rejects the request" do
+            key_id_actor_id = "https://remote.com/u/key-id/#{SecureRandom.hex(8)}"
+            key_id = "#{key_id_actor_id}#main-key"
+            actor_json = build_actor_json(public_key: keypair.public_key.to_pem)
+            actor_json[:id] = "https://another-remote.com/u/attacker/#{SecureRandom.hex(8)}"
+            actor_json[:inbox] = "#{actor_json[:id]}/inbox"
+            actor_json[:outbox] = "#{actor_json[:id]}/outbox"
+            actor_json[:publicKey][:id] = "#{actor_json[:id]}#main-key"
+            actor_json[:publicKey][:owner] = actor_json[:id]
+
+            stub_request(:get, key_id_actor_id).to_return(
+              body: actor_json.to_json,
+              headers: {
+                "Content-Type" => "application/json",
+              },
+              status: 200,
+            )
+
+            headers = build_post_headers(key_id: key_id, keypair: keypair)
+            post_to_inbox(group, body: post_body, headers: headers)
+
+            expect_request_error(response, "actor_not_found_for_key", 401, key_id: key_id)
+            expect(DiscourseActivityPubActor.exists?(ap_id: actor_json[:id])).to eq(false)
+          end
+        end
+
         context "with an actor keyId on an allowed internal host" do
           before do
             setup_logging


### PR DESCRIPTION
## Summary

Prevent actor spoofing in HTTP Signature verification by ensuring the resolved actor document's identity and public key owner match the provided keyId URI. The fix also enforces domain-based authorization policies on the final verified actor identity to prevent bypassing access controls via malicious key redirection.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1404
- Affected file: https://github.com/discourse/discourse-activity-pub/blob/main/app/controllers/discourse_activity_pub/a_p/inboxes_controller.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>