### PR TITLE
SECURITY: acct keyIds still bypass actor/public-key binding checks

### DIFF
--- a/app/controllers/concerns/discourse_activity_pub/signature_verification.rb
+++ b/app/controllers/concerns/discourse_activity_pub/signature_verification.rb
@@ -222,9 +222,10 @@ module DiscourseActivityPub
 
     def actor_from_key_id(key_id)
       ap_id = key_id.split("#").first
+      acct_key_id = ap_id.start_with?("acct:")
       domain =
         (
-          if ap_id.start_with?("acct:")
+          if acct_key_id
             ap_id.split("@").last
           else
             DiscourseActivityPub::URI.domain_from_uri(ap_id)
@@ -236,17 +237,24 @@ module DiscourseActivityPub
         return
       end
 
-      if ap_id.start_with?("acct:")
-        actor = DiscourseActivityPubActor.find_by_handle(ap_id.gsub(/\Aacct:/, ""), local: false)
-      else
-        actor = DiscourseActivityPubActor.find_by(ap_id: ap_id)
+      if acct_key_id
+        ap_id = actor_id_from_acct_key_id(ap_id)
+        return unless ap_id
 
-        if !actor
-          ap_actor = AP::Actor.resolve(ap_id)
-          if resolved_actor_matches_key_id_actor?(ap_actor, ap_id)
-            ap_actor.apply_handlers(ap_actor.type, :store)
-            actor = ap_actor.stored
-          end
+        unless domain_allowed?(DiscourseActivityPub::URI.domain_from_uri(ap_id))
+          @signature_verification_failure_code = 403
+          return
+        end
+      end
+
+      actor = DiscourseActivityPubActor.find_by(ap_id: ap_id)
+
+      if acct_key_id || !actor
+        actor = nil
+        ap_actor = AP::Actor.resolve(ap_id)
+        if resolved_actor_matches_key_id_actor?(ap_actor, ap_id)
+          ap_actor.apply_handlers(ap_actor.type, :store)
+          actor = ap_actor.stored
         end
       end
 
@@ -258,6 +266,28 @@ module DiscourseActivityPub
       end
 
       actor
+    end
+
+    def actor_id_from_acct_key_id(acct_key_id)
+      handle =
+        DiscourseActivityPub::Webfinger::Handle.new(
+          handle: acct_key_id.delete_prefix("#{DiscourseActivityPub::Webfinger::ACCOUNT_SCHEME}:"),
+        )
+      return unless handle.valid?
+
+      account = DiscourseActivityPub::Webfinger.resolve_handle(handle.to_s)
+      return unless account.is_a?(Hash)
+      return if account.blank?
+      return if account["subject"] != "#{DiscourseActivityPub::Webfinger::ACCOUNT_SCHEME}:#{handle}"
+
+      links = account["links"]
+      return unless links.is_a?(Array)
+
+      link =
+        links.find do |webfinger_link|
+          webfinger_link["rel"] == "self" && webfinger_link["href"].present?
+        end
+      link && link["href"]
     end
 
     def resolved_actor_matches_key_id_actor?(ap_actor, ap_id)

--- a/spec/requests/discourse_activity_pub/ap/inboxes_controller_spec.rb
+++ b/spec/requests/discourse_activity_pub/ap/inboxes_controller_spec.rb
@@ -360,6 +360,49 @@ RSpec.describe DiscourseActivityPub::AP::InboxesController do
           end
         end
 
+        context "with an acct keyId whose public key id does not match" do
+          before { setup_logging }
+          after { teardown_logging }
+
+          it "rejects the request" do
+            username = "victim-#{SecureRandom.hex(8)}"
+            handle = "#{username}@remote.com"
+            key_id = "acct:#{handle}"
+            actor_json =
+              build_actor_json(preferredUsername: username, public_key: keypair.public_key.to_pem)
+            attacker_public_key_id = "https://remote.com/u/attacker/#{SecureRandom.hex(8)}#main-key"
+            actor_json[:publicKey][:id] = attacker_public_key_id
+
+            stub_request(:get, "https://remote.com/.well-known/webfinger").with(
+              query: {
+                "resource" => key_id,
+              },
+            ).to_return(
+              body: {
+                subject: key_id,
+                links: [DiscourseActivityPub::Webfinger.activity_link(actor_json[:id])],
+              }.to_json,
+              headers: {
+                "Content-Type" => DiscourseActivityPub::Webfinger::CONTENT_TYPE,
+              },
+              status: 200,
+            )
+            stub_request(:get, actor_json[:id]).to_return(
+              body: actor_json.to_json,
+              headers: {
+                "Content-Type" => "application/json",
+              },
+              status: 200,
+            )
+
+            headers = build_post_headers(key_id: key_id, keypair: keypair)
+            post_to_inbox(group, body: post_body, headers: headers)
+
+            expect_request_error(response, "actor_not_found_for_key", 401, key_id: key_id)
+            expect(DiscourseActivityPubActor.exists?(ap_id: actor_json[:id])).to eq(false)
+          end
+        end
+
         context "with an actor keyId on an allowed internal host" do
           before do
             setup_logging


### PR DESCRIPTION
## Summary

Correctly validate acct: HTTP Signature keyIds by resolving them via WebFinger and enforcing actor-to-public-key binding checks. This prevents remote actors from being associated with unauthorized public keys during ActivityPub signature verification.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1421

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>