### PR TITLE
SECURITY: Forged ActivityPub Accept can mint trusted local follow rows

### DIFF
--- a/app/models/discourse_activity_pub_follow.rb
+++ b/app/models/discourse_activity_pub_follow.rb
@@ -4,6 +4,8 @@ class DiscourseActivityPubFollow < ActiveRecord::Base
   belongs_to :follower, class_name: "DiscourseActivityPubActor"
   belongs_to :followed, class_name: "DiscourseActivityPubActor"
 
+  validates :follower_id, uniqueness: { scope: :followed_id }
+
   def followed_at
     created_at
   end
@@ -18,6 +20,10 @@ end
 #  followed_id :bigint           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  idx_discourse_activity_pub_follows_unique_pair  (follower_id,followed_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/db/migrate/20260708175639_add_unique_index_to_discourse_activity_pub_follows.rb
+++ b/db/migrate/20260708175639_add_unique_index_to_discourse_activity_pub_follows.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+class AddUniqueIndexToDiscourseActivityPubFollows < ActiveRecord::Migration[8.0]
+  INDEX_NAME = "idx_discourse_activity_pub_follows_unique_pair"
+
+  def up
+    execute <<~SQL
+      DELETE FROM discourse_activity_pub_follows
+      WHERE id IN (
+        SELECT id
+        FROM (
+          SELECT
+            id,
+            row_number() OVER (
+              PARTITION BY follower_id, followed_id
+              ORDER BY id
+            ) AS row_number
+          FROM discourse_activity_pub_follows
+        ) duplicates
+        WHERE duplicates.row_number > 1
+      )
+    SQL
+
+    add_index :discourse_activity_pub_follows,
+              %i[follower_id followed_id],
+              unique: true,
+              name: INDEX_NAME
+  end
+
+  def down
+    remove_index :discourse_activity_pub_follows, name: INDEX_NAME
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -745,12 +745,17 @@ after_initialize do
   activity_pub_on(:accept, :perform) do |activity|
     case activity.object.type
     when DiscourseActivityPub::AP::Activity::Follow.type
-      DiscourseActivityPubFollow.create!(
-        follower_id: activity.object.actor.stored.id,
-        followed_id: activity.actor.stored.id,
-      )
-      message = { model: { id: activity.object.actor.stored.model.id, type: "category" } }
-      MessageBus.publish("/activity-pub", message)
+      if activity.object.stored.local? &&
+           activity.object.object.stored.id == activity.actor.stored.id
+        DiscourseActivityPubFollow.find_or_create_by!(
+          follower_id: activity.object.actor.stored.id,
+          followed_id: activity.actor.stored.id,
+        )
+        message = { model: { id: activity.object.actor.stored.model.id, type: "category" } }
+        MessageBus.publish("/activity-pub", message)
+      else
+        false
+      end
     else
       false
     end

--- a/spec/lib/discourse_activity_pub/ap/activity/accept_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/accept_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Accept do
           let!(:follow) do
             Fabricate(
               :discourse_activity_pub_activity_follow,
+              local: true,
               actor: category.activity_pub_actor,
               object: followed_actor,
             )
@@ -51,6 +52,50 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Accept do
                 follower_id: category.activity_pub_actor.id,
               ),
             ).to eq(true)
+          end
+        end
+
+        context "when the accepted follow was for another actor" do
+          let!(:accepted_actor) do
+            Fabricate(
+              :discourse_activity_pub_actor_person,
+              ap_id: "https://mastodon.pavilion.tech/users/accepted",
+              local: false,
+            )
+          end
+          let!(:forging_actor) do
+            Fabricate(
+              :discourse_activity_pub_actor_person,
+              ap_id: "https://mastodon.pavilion.tech/users/forger",
+              local: false,
+            )
+          end
+          let!(:follow) do
+            Fabricate(
+              :discourse_activity_pub_activity_follow,
+              local: true,
+              actor: category.activity_pub_actor,
+              object: accepted_actor,
+            )
+          end
+
+          it "does not create a follow for the accepting actor" do
+            json =
+              build_activity_json(
+                id: "#{forging_actor.ap_id}#accepts/follows/forged",
+                type: "Accept",
+                actor: forging_actor,
+                object: follow.ap.json,
+              )
+
+            perform_process(json)
+
+            expect(
+              DiscourseActivityPubFollow.exists?(
+                followed_id: forging_actor.id,
+                follower_id: category.activity_pub_actor.id,
+              ),
+            ).to eq(false)
           end
         end
       end

--- a/spec/models/discourse_activity_pub_follow_spec.rb
+++ b/spec/models/discourse_activity_pub_follow_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseActivityPubFollow do
+  fab!(:follower, :discourse_activity_pub_actor_group)
+  fab!(:followed) { Fabricate(:discourse_activity_pub_actor_person, local: false) }
+
+  describe "#create" do
+    it "does not allow duplicate follower and followed pairs" do
+      Fabricate(:discourse_activity_pub_follow, follower: follower, followed: followed)
+
+      duplicate = described_class.new(follower: follower, followed: followed)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:follower_id]).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Correctly verify that incoming ActivityPub Accept(Follow) activities correspond to a local follow request and that the sender is the intended actor. This prevents remote actors from forging acceptances to create unauthorized follow relationships, and includes hardening to prevent duplicate follow records via a new database index.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1414

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>