### PR TITLE
FIX: Don't count federated post updates against the author's edit limit

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -648,7 +648,7 @@ after_initialize do
   activity_pub_on(:update, :perform) do |activity|
     post = activity.object.stored.model
     revisor = PostRevisor.new(post)
-    revisor.revise!(post.user, { raw: activity.object.content })
+    revisor.revise!(post.user, { raw: activity.object.content }, bypass_rate_limiter: true)
   end
   activity_pub_on(:like, :perform) do |activity|
     user = DiscourseActivityPub::ActorHandler.update_or_create_user(activity.actor.stored)


### PR DESCRIPTION
Previously, inbound `Update` activities revised the local post as `post.user`, which for remote content is the staged shadow user created for that actor. Staged users are not staff, so they are not exempt from `EditRateLimiter` and every federated edit counted against their daily `max_edits_per_day` allowance. Once spent, `RateLimiter::LimitExceeded` was raised inside the surrounding transaction, rolling back the stored activity along with the edit — so the activity was never marked processed and each retry failed the same way. A remote instance controls how quickly this happens.

This change passes `bypass_rate_limiter` so federated updates are no longer metered against the shadow user who did not make them.