### PR TITLE
FIX: Accept announced activities signed by the announcing actor

### DIFF
--- a/lib/discourse_activity_pub/a_p/activity.rb
+++ b/lib/discourse_activity_pub/a_p/activity.rb
@@ -144,7 +144,9 @@ module DiscourseActivityPub
       end
 
       def signed_actor_matches?
-        signed_actor_ap_id.blank? || actor.id == signed_actor_ap_id
+        return true if signed_actor_ap_id.blank?
+        return true if actor.id == signed_actor_ap_id
+        !!(parent&.announce? && parent.actor&.id == signed_actor_ap_id)
       end
 
       def activity_host_matches_object_host?

--- a/spec/lib/discourse_activity_pub/ap/activity/announce_spec.rb
+++ b/spec/lib/discourse_activity_pub/ap/activity/announce_spec.rb
@@ -43,6 +43,39 @@ RSpec.describe DiscourseActivityPub::AP::Activity::Announce do
             DiscourseActivityPub::AP::Activity::Create.any_instance.expects(:process).once
             perform_process(announce_json)
           end
+
+          context "when the announcing group signed the delivery" do
+            let!(:follow) do
+              Fabricate(
+                :discourse_activity_pub_follow,
+                follower: category.activity_pub_actor,
+                followed: followed_actor,
+              )
+            end
+            let!(:note_actor_json) { build_actor_json }
+            let!(:object_json) do
+              build_object_json(attributed_to: note_actor_json[:id], name: "My cool topic title")
+            end
+            let!(:create_json) do
+              build_activity_json(
+                type: "Create",
+                actor: note_actor_json,
+                object: object_json,
+                to: [category_actor.ap_id],
+              )
+            end
+
+            it "creates the topic" do
+              perform_process(
+                announce_json,
+                category_actor.ap_id,
+                signed_actor_ap_id: followed_actor_id,
+              )
+              post = Post.find_by(raw: object_json[:content])
+              expect(post.present?).to eq(true)
+              expect(post.topic.title).to eq(object_json[:name])
+            end
+          end
         end
 
         context "when announcing an object" do


### PR DESCRIPTION
When an `Announce` wraps an activity, `Announce#process` copies the signer into the inner activity, and then `signed_actor_matches?` compares it with the inner actor. But a Group announces posts written by its members and signs the request itself, so the signer is the Group and the inner actor is the member. They are never the same, so the check always fails and the post is dropped with "Signed actor must match Activity actor".

I tested on a real instance, same payload:

| signer | result |
| --- | --- |
| the Group (what is really sent) | rejected, no topic |
| none | topic created |
| the Group, with this patch | topic created |

Is this check meant to run for announced activities? It looks to me like it should only apply when the activity is delivered directly. The Announce is already checked against the signer, and `create :validate` still requires the category to follow the announcer. So here I also accept the announcer when the activity comes from its own Announce.

The specs pass today because they run without a signer, or with `activity_pub_require_signed_requests = false`. I added one with a signer, it fails on main.
