### PR TITLE
DEV: Use user.visibleGroups instead of deprecated user.groups

### DIFF
--- a/assets/javascripts/discourse/lib/activity-pub-utilities.js
+++ b/assets/javascripts/discourse/lib/activity-pub-utilities.js
@@ -24,7 +24,7 @@ export function showStatusToUser(user, siteSettings) {
 
   return (
     groupIds.includes(AUTO_GROUPS.everyone.id) ||
-    user?.groups.some((group) => groupIds.includes(group.id))
+    user?.visibleGroups.some((group) => groupIds.includes(group.id))
   );
 }
 

--- a/test/javascripts/acceptance/activity-pub-topic-test.js
+++ b/test/javascripts/acceptance/activity-pub-topic-test.js
@@ -59,7 +59,7 @@ acceptance(
     needs.user({
       moderator: false,
       admin: false,
-      groups: [AUTO_GROUPS.trust_level_0, AUTO_GROUPS.trust_level_1],
+      visibleGroups: [AUTO_GROUPS.trust_level_0, AUTO_GROUPS.trust_level_1],
     });
 
     setupServer(needs, [


### PR DESCRIPTION
Core renamed User#groups to User#visibleGroups in discourse/discourse#42711, leaving the old name behind as a getter that logs the discourse.user.groups deprecation. This migrates both call sites: showStatusToUser now reads user.visibleGroups, and the topic acceptance test passes visibleGroups to needs.user.